### PR TITLE
Simplify iterator stream management. The iterator stream-read thread is the only one to close the row channel. Also, it will cancel the GRPC stream as necessary. Closes #74

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -264,6 +264,7 @@ func goFdwReScanForeignScan(node *C.ForeignScanState) {
 
 //export goFdwEndForeignScan
 func goFdwEndForeignScan(node *C.ForeignScanState) {
+
 	s := GetExecState(node.fdw_state)
 	pluginHub, _ := hub.GetHub()
 	if s != nil && pluginHub != nil {

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -233,6 +233,7 @@ func (h *Hub) startScanForConnection(connectionName string, table string, qualMa
 	}
 
 	// cache not enabled - create a scan iterator
+	log.Printf("[TRACE] startScanForConnection creating a new scan iterator")
 	queryContext := proto.NewQueryContext(columns, qualMap, limit)
 	iterator := newScanIterator(h, connection, table, qualMap, columns, limit)
 
@@ -368,11 +369,6 @@ func (h *Hub) startScan(iterator *scanIterator, queryContext *proto.QueryContext
 	table := iterator.table
 	log.Printf("[INFO] StartScan\n  table: %s", table)
 	c := iterator.connection
-
-	// if a scanIterator is in progress, fail
-	if iterator.inProgress() {
-		return fmt.Errorf("cannot start scanIterator while existing scanIterator is incomplete - cancel first")
-	}
 
 	req := &proto.ExecuteRequest{
 		Table:        table,


### PR DESCRIPTION
…