### PR TITLE
Fixes issue where FDW logs were using a different format from Postgres. Closes #134

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"time"
 	"unsafe"
 
 	"github.com/hashicorp/go-hclog"
@@ -44,8 +45,11 @@ func init() {
 		// suppress logs
 		log.SetOutput(ioutil.Discard)
 	}
-
-	logger = logging.NewLogger(&hclog.LoggerOptions{Name: "hub"})
+	logger = logging.NewLogger(&hclog.LoggerOptions{
+		Name:       "hub",
+		TimeFn:     func() time.Time { return time.Now().UTC() },
+		TimeFormat: "2006-01-02 15:04:05.000 UTC",
+	})
 	log.SetOutput(logger.StandardWriter(&hclog.StandardLoggerOptions{InferLevels: true}))
 	log.SetPrefix("")
 	log.SetFlags(0)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/protobuf v1.5.2
-	github.com/hashicorp/go-hclog v0.15.0
+	github.com/hashicorp/go-hclog v1.1.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/turbot/go-kit v0.3.0
 	// main

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,9 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0Mvsk=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.1.0 h1:QsGcniKx5/LuX2eYoeL+Np3UKYPNaN7YKpTh29h8rbw=
+github.com/hashicorp/go-hclog v1.1.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v0.0.0-20180129170900-7f3cd4390caa/go.mod h1:6ij3Z20p+OhOkCSrA0gImAWoHYQRGbnlcuk6XYTiaRw=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=


### PR DESCRIPTION
New Log format:

```
2022-01-20 11:11:04.457 UTC [WARN]  hub: stream receive error rpc error: code = Unknown desc = AccessDenied: Access Denied
	status code: 403, request id: 6HYTK9CNWN1B3RD5, host id: tiRXRczuLNRF8dByv7lXP1SyV3uPzdyPCj/lV+Lh7f3M9KtWiXGYo8DtYXrD20l9xdcvBwYNIhA= (0xc0004f4a50)
2022-01-20 11:11:04.457 UTC [63682] ERROR:  rpc error: code = Unknown desc = AccessDenied: Access Denied
		status code: 403, request id: 6HYTK9CNWN1B3RD5, host id: tiRXRczuLNRF8dByv7lXP1SyV3uPzdyPCj/lV+Lh7f3M9KtWiXGYo8DtYXrD20l9xdcvBwYNIhA=
2022-01-20 11:11:04.457 UTC [63682] STATEMENT:  select * from aws_s3_bucket
2022-01-20 11:11:04.466 UTC [63682] LOG:  disconnection: session time: 0:00:05.373 user=steampipe database=steampipe host=::1 port=62872
```