### PR TITLE
Fix nil reference panic when a scan fails to start - do not add an iterator to Hub.runningIterators until scan is started successfully. Closes #298

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -192,6 +192,7 @@ func goFdwBeginForeignScan(node *C.ForeignScanState, eflags C.int) {
 			FdwError(fmt.Errorf("%v", r))
 		}
 	}()
+	log.Printf("[TRACE] goFdwBeginForeignScan")
 	// read the explain flag
 	explain := eflags&C.EXEC_FLAG_EXPLAIN_ONLY == C.EXEC_FLAG_EXPLAIN_ONLY
 

--- a/fdw.go
+++ b/fdw.go
@@ -64,6 +64,8 @@ func init() {
 func goFdwGetRelSize(state *C.FdwPlanState, root *C.PlannerInfo, rows *C.double, width *C.int, baserel *C.RelOptInfo) {
 	logging.ClearProfileData()
 
+	log.Printf("[TRACE] goFdwGetRelSize")
+
 	pluginHub, err := hub.GetHub()
 	if err != nil {
 		FdwError(err)
@@ -110,6 +112,7 @@ func goFdwGetPathKeys(state *C.FdwPlanState) *C.List {
 		}
 	}()
 
+	log.Printf("[TRACE] goFdwGetPathKeys")
 	pluginHub, err := hub.GetHub()
 	if err != nil {
 		FdwError(err)
@@ -167,6 +170,7 @@ func goFdwExplainForeignScan(node *C.ForeignScanState, es *C.ExplainState) {
 		}
 	}()
 
+	log.Printf("[TRACE] goFdwExplainForeignScan")
 	s := GetExecState(node.fdw_state)
 	if s == nil {
 		return

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -34,7 +34,9 @@ const (
 
 // Hub is a structure representing plugin hub
 type Hub struct {
-	connections      *connectionFactory
+	connections *connectionFactory
+
+	// list of iterators currently executing scans
 	runningIterators []Iterator
 
 	// if the cache is enabled/disabled by a metacommand, this will be non null
@@ -308,8 +310,6 @@ func (h *Hub) GetIterator(columns []string, quals *proto.Quals, unhandledRestric
 		return nil, err
 	}
 
-	// store the iterator
-	h.addIterator(iterator)
 	return iterator, nil
 }
 
@@ -698,6 +698,10 @@ func (h *Hub) StartScan(i Iterator) error {
 		return err
 	}
 	iterator.Start(stream, ctx, cancel)
+
+	// add iterator to running list
+	h.addIterator(iterator)
+
 	return nil
 }
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -389,7 +389,6 @@ func (h *Hub) GetRelSize(columns []string, quals []*proto.Qual, opts types.Optio
 //	    For example, the return value corresponding to the previous scenario would be::
 //	        [(('id',), 1)]
 func (h *Hub) GetPathKeys(opts types.Options) ([]types.PathKey, error) {
-
 	connectionName := opts["connection"]
 	table := opts["table"]
 

--- a/quals.go
+++ b/quals.go
@@ -72,7 +72,7 @@ func restrictionsToQuals(node *C.ForeignScanState, cinfos *conversionInfos) (qua
 		log.Printf("[TRACE] %s", grpc.QualToString(q))
 	}
 	if unhandledRestrictions > 0 {
-		log.Printf("[WARN] RestrictionsToQuals: failed to convert %s %s to quals",
+		log.Printf("[WARN] RestrictionsToQuals: failed to convert %d %s to quals",
 			unhandledRestrictions,
 			pluralize.NewClient().Pluralize("restriction", unhandledRestrictions, false))
 	}


### PR DESCRIPTION
…