### PR TITLE
Updated PostgreSQL Version Support to 14.0 in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Overview
 
-The Steampipe Postgres Foreign Data Wrapper (FDW) is a PostgreSQL 12.0 extension that is used by Steampipe plugins to interface with Postgres. Similar to [Multicorn](https://github.com/Segfault-Inc/Multicorn) for Python, the Steampipe FDW simplifies writing foreign data wrappers in Go for use in plugins.
+The Steampipe Postgres Foreign Data Wrapper (FDW) is a PostgreSQL 14.0 extension that is used by Steampipe plugins to interface with Postgres. Similar to [Multicorn](https://github.com/Segfault-Inc/Multicorn) for Python, the Steampipe FDW simplifies writing foreign data wrappers in Go for use in plugins.
 
 Steampipe uses a Postgres Foreign Data Wrapper to present data from external systems and services as database tables. The Steampipe Foreign Data Wrapper (FDW) provides a Postgres extension that allows Postgres to connect to external data in a standardized way. The Steampipe FDW does not directly interface with external systems, but instead relies on plugins to implement the API/provider specific code and return it in a standard format via gRPC. This approach simplifies extending Steampipe as the Postgres-specific logic is encapsulated in the FDW, and API and service specific code resides only in the plugin.
 


### PR DESCRIPTION
The Readme's ["Overview"](https://github.com/turbot/steampipe-postgres-fdw#overview)  emphasized the service relied on PostgreSQL 12.0, but the ["Building the FDW"](https://github.com/turbot/steampipe-postgres-fdw#building-the-fdw)  section directed users to install version 14.

I was not sure which version the service relied on. After searching for clarification, I found a [blog post](https://steampipe.io/docs/sql/steampipe-sql) on Steampipe's website that asserted PostgreSQL 14 is the current targeted version.

I just changed PostgreSQL 12 to 14 in the overview.