### PR TITLE
feat: mark FDW as PARALLEL SAFE to improve performance

### DIFF
--- a/fdw/README.md
+++ b/fdw/README.md
@@ -76,7 +76,7 @@ consider forking Fdw.)
                                       |   +-----------+
                                       |
 +----------+     +-----------+  gRPC  |   +-----------+
-| Postgres |=====| Fdw |--------+-->| google_*  |
+| Postgres |=====| Fdw       |--------+-->| google_*  |
 +----------+     +-----------+        |   +-----------+
                                       |
                                       |   +-----------+
@@ -100,4 +100,6 @@ consider forking Fdw.)
 * [oracle_fdw](https://github.com/laurenz/oracle_fdw) is C-based.
 
 
-* [Query planning in Foreign Data Wrappers](https://www.postgresql.org/docs/13/fdw-planning.html)
+* [Query planning in Foreign Data Wrappers](https://www.postgresql.org/docs/14/fdw-planning.html)
+* [Parallel safety](https://www.postgresql.org/docs/14/parallel-safety.html)
+* [FDW Routines for Parallel Execution](https://www.postgresql.org/docs/14/fdw-callbacks.html#FDW-CALLBACKS-PARALLEL)

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -55,6 +55,10 @@ void exitHook(int code, Datum arg)
   goFdwShutdown();
 }
 
+static bool fdwIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte) {
+	return true;
+}
+
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
 {
   // initialise logging`

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -56,7 +56,7 @@ void exitHook(int code, Datum arg)
 }
 
 static bool fdwIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte) {
-	return true;
+	return getenv("STEAMPIPE_FDW_PARALLEL_SAFE") != NULL;
 }
 
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)

--- a/fdw/fdw_handlers.h
+++ b/fdw/fdw_handlers.h
@@ -2,6 +2,7 @@
 // defined and available.
 #include "fmgr.h"
 
+static bool fdwIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte);
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static ForeignScan *fdwGetForeignPlan(
@@ -21,6 +22,7 @@ PG_FUNCTION_INFO_V1(fdw_validator);
 
 Datum fdw_handler(PG_FUNCTION_ARGS) {
   FdwRoutine *fdw_routine = makeNode(FdwRoutine);
+  fdw_routine->IsForeignScanParallelSafe = fdwIsForeignScanParallelSafe;
   fdw_routine->GetForeignRelSize = fdwGetForeignRelSize;
   fdw_routine->GetForeignPaths = fdwGetForeignPaths;
   fdw_routine->GetForeignPlan = fdwGetForeignPlan;


### PR DESCRIPTION
This PR marks the Steampipe FDW as [PARALLEL SAFE](https://www.postgresql.org/docs/16/fdw-callbacks.html#FDW-CALLBACKS-PARALLEL) to improve performance by parallelizing foreign scans.

For now, the feature is disabled by default, set the `STEAMPIPE_FDW_PARALLEL_SAFE` before starting the Steampipe service to any value to enable it.

Considering this query:
```sql
SELECT 'APIGATEWAY' AS subtype, row_to_json(r) AS data FROM (SELECT
  -- common
  name,
  api_id AS "resourceId",
  region AS "regionName",
  tags,
  -- specific
  concat(api_id, '.execute-api.eu-west-3.amazonaws.com') AS "apiEndpoint",
  api_id AS "apiId",
  description,
  'REST' AS "protocolType",
  '1' AS "awsServiceVersion"
FROM
  aws_api_gateway_rest_api
UNION ALL
SELECT
  -- common
  name,
  api_id AS "resourceId",
  region AS "regionName",
  tags,
  -- specific
  api_endpoint AS "apiEndpoint",
  api_id AS "apiId",
  description,
  protocol_type AS "protocolType",
  '2' AS "awsServiceVersion"
FROM
  aws_api_gatewayv2_api
) r
UNION ALL
SELECT 'ASG' AS subtype, row_to_json(r) AS data FROM (SELECT
  -- common
  name,
  autoscaling_group_arn AS "resourceId",
  region AS "regionName",
  tags,
  -- specific
  name AS "autoScalingGroupName",
  desired_capacity AS "desiredCapacity",
  instances, -- FIXME
  max_size AS "maxSize",
  min_size AS "minSize"
FROM
  aws_ec2_autoscaling_group
) r
```

Without this PR, `EXPLAIN VERBOSE` returns:

```
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Append  (cost=0.00..200000000015000.00 rows=3000000 width=667)                                                                                                                                                                                                                                                                                                                            |
|   ->  Foreign Scan on aws.aws_api_gateway_rest_api  (cost=0.00..50000000000000.00 rows=1000000 width=500)                                                                                                                                                                                                                                                                                 |
|         Output: 'APIGATEWAY'::text, row_to_json(ROW(aws_api_gateway_rest_api.name, aws_api_gateway_rest_api.api_id, aws_api_gateway_rest_api.region, aws_api_gateway_rest_api.tags, concat(aws_api_gateway_rest_api.api_id, '.execute-api.eu-west-3.amazonaws.com'), aws_api_gateway_rest_api.api_id, aws_api_gateway_rest_api.description, 'REST'::text, '1'::text))                     |
|   ->  Foreign Scan on aws.aws_api_gatewayv2_api  (cost=0.00..70000000000000.00 rows=1000000 width=700)                                                                                                                                                                                                                                                                                    |
|         Output: 'APIGATEWAY'::text, row_to_json(ROW(aws_api_gatewayv2_api.name, aws_api_gatewayv2_api.api_id, aws_api_gatewayv2_api.region, aws_api_gatewayv2_api.tags, aws_api_gatewayv2_api.api_endpoint, aws_api_gatewayv2_api.api_id, aws_api_gatewayv2_api.description, aws_api_gatewayv2_api.protocol_type, '2'::text))                                                             |
|   ->  Foreign Scan on aws.aws_ec2_autoscaling_group  (cost=0.00..80000000000000.00 rows=1000000 width=800)                                                                                                                                                                                                                                                                                |
|         Output: 'ASG'::text, row_to_json(ROW(aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.autoscaling_group_arn, aws_ec2_autoscaling_group.region, aws_ec2_autoscaling_group.tags, aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.desired_capacity, aws_ec2_autoscaling_group.instances, aws_ec2_autoscaling_group.max_size, aws_ec2_autoscaling_group.min_size)) |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```

With this PR:

```
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                   >
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| Gather  (cost=1000.00..120000000307250.00 rows=3000000 width=64)                                                                                                                                                                                                                                                                                                                             >
|   Output: ('ASG'::text), (row_to_json(ROW(aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.autoscaling_group_arn, aws_ec2_autoscaling_group.region, aws_ec2_autoscaling_group.tags, aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.desired_capacity, aws_ec2_autoscaling_group.instances, aws_ec2_autoscaling_group.max_size, aws_ec2_autoscaling_group.min_size)))      >
|   Workers Planned: 2                                                                                                                                                                                                                                                                                                                                                                         >
|   ->  Parallel Append  (cost=0.00..120000000006250.00 rows=1250001 width=667)                                                                                                                                                                                                                                                                                                                >
|         ->  Foreign Scan on aws_706303552994.aws_ec2_autoscaling_group  (cost=0.00..80000000000000.00 rows=1000000 width=800)                                                                                                                                                                                                                                                                >
|               Output: 'ASG'::text, row_to_json(ROW(aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.autoscaling_group_arn, aws_ec2_autoscaling_group.region, aws_ec2_autoscaling_group.tags, aws_ec2_autoscaling_group.name, aws_ec2_autoscaling_group.desired_capacity, aws_ec2_autoscaling_group.instances, aws_ec2_autoscaling_group.max_size, aws_ec2_autoscaling_group.min_size>
|         ->  Foreign Scan on aws_706303552994.aws_api_gatewayv2_api  (cost=0.00..70000000000000.00 rows=1000000 width=700)                                                                                                                                                                                                                                                                    >
|               Output: 'APIGATEWAY'::text, row_to_json(ROW(aws_api_gatewayv2_api.name, aws_api_gatewayv2_api.api_id, aws_api_gatewayv2_api.region, aws_api_gatewayv2_api.tags, aws_api_gatewayv2_api.api_endpoint, aws_api_gatewayv2_api.api_id, aws_api_gatewayv2_api.description, aws_api_gatewayv2_api.protocol_type, '2'::text))                                                          >
|         ->  Foreign Scan on aws_706303552994.aws_api_gateway_rest_api  (cost=0.00..50000000000000.00 rows=1000000 width=500)                                                                                                                                                                                                                                                                 >
|               Output: 'APIGATEWAY'::text, row_to_json(ROW(aws_api_gateway_rest_api.name, aws_api_gateway_rest_api.api_id, aws_api_gateway_rest_api.region, aws_api_gateway_rest_api.tags, concat(aws_api_gateway_rest_api.api_id, '.execute-api.eu-west-3.amazonaws.com'), aws_api_gateway_rest_api.api_id, aws_api_gateway_rest_api.description, 'REST'::text, '1'::text))                  >
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
```

For reference:

* https://www.postgresql.org/docs/16/fdw-callbacks.html#FDW-CALLBACKS-PARALLEL
* https://www.postgresql.org/docs/current/parallel-safety.html
* https://www.highgo.ca/2021/09/03/implement-foreign-scan-with-fdw-interface-api/