### PR TITLE
fix: OpenTelemetry metric names must only contain [A-Za-z0-9_.-]

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -120,7 +120,7 @@ func (h *Hub) initialiseTelemetry() error {
 	h.telemetryShutdownFunc = shutdownTelemetry
 
 	hydrateCalls, err := otel.GetMeterProvider().Meter(constants.FdwName).Int64Counter(
-		fmt.Sprintf("%s/hydrate_calls_total", constants.FdwName),
+		fmt.Sprintf("%s-hydrate_calls_total", constants.FdwName),
 		metric.WithDescription("The total number of hydrate calls"),
 	)
 	if err != nil {


### PR DESCRIPTION
Without this change, using telemetry fails with:

```
2023-10-26 10:40:25.998 UTC [TRACE] hub: init telemetry end
2023-10-26 10:40:25.998 UTC [WARN]  hub: init telemetry failed to create hydrateCallsCounter
2023-10-26 10:40:25.998 UTC [1655556] FATAL:  invalid instrument name: steampipe-postgres-fdw/hydrate_calls_total: must only contain [A-Za-z0-9_.-]
```