### PR TITLE
fix: fmt.Errorf format %s has arg metadataCount of wrong type int

### DIFF
--- a/hub/hub_base.go
+++ b/hub/hub_base.go
@@ -354,7 +354,7 @@ func (h *hubBase) executeCommandScan(connectionName, table string, queryTimestam
 		return newInMemoryIterator(connectionName, res, queryTimestamp), nil
 	case constants.ForeignTableScanMetadata, constants.LegacyCommandTableScanMetadata:
 		if metadataCount := len(h.queryTiming.scanMetadata); metadataCount > 1 {
-			return nil, fmt.Errorf(" executeCommandScan for table '%s' - %d summaries in metadata store - there should only be 1. ", metadataCount, table)
+			return nil, fmt.Errorf(" executeCommandScan for table '%s' - %d summaries in metadata store - there should only be 1. ", table, metadataCount)
 		}
 
 		res := &QueryResult{}


### PR DESCRIPTION
This PR resolves the following error:

```
# go test ./hub/
# github.com/turbot/steampipe-postgres-fdw/hub
# [github.com/turbot/steampipe-postgres-fdw/hub]
hub/hub_base.go:359:16: fmt.Errorf format %s has arg metadataCount of wrong type int
FAIL    github.com/turbot/steampipe-postgres-fdw/hub [build failed]
FAIL
```