### PR TITLE
fix: warning: ‘deserializeDeparsedSortListCell’ declared ‘static’ but never defined [-Wunused-function]

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -9,8 +9,6 @@ package main
 #include "nodes/pg_list.h"
 #include "utils/timestamp.h"
 
-static Name deserializeDeparsedSortListCell(ListCell *lc);
-
 */
 import "C"
 


### PR DESCRIPTION
This PR fixes the following error:

```
Error: fdw.go:12:13: warning: ‘deserializeDeparsedSortListCell’ declared ‘static’ but never defined [-Wunused-function]

```

See https://github.com/turbot/steampipe-postgres-fdw/actions/runs/15683515505/job/44180853878#step:13:1312