### PR TITLE
feat: support propagation of OpenTelemetry context from clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 steampipe_postgres_fdw.h
 # generated C imports
 0_prebuild.go
+prebuild.go
 
 # Binaries for programs and plugins
 *.exe

--- a/fdw.go
+++ b/fdw.go
@@ -172,6 +172,18 @@ func goFdwGetRelSize(state *C.FdwPlanState, root *C.PlannerInfo, rows *C.double,
 
 	tableOpts := GetFTableOptions(types.Oid(state.foreigntableid))
 
+	// Extract trace context if available
+	var traceContext string
+	if state.trace_context_string != nil {
+		traceContext = C.GoString(state.trace_context_string)
+		log.Printf("[TRACE] Extracted trace context from session: %s", traceContext)
+	}
+
+	// Add trace context to options for hub layer
+	if traceContext != "" {
+		tableOpts["trace_context"] = traceContext
+	}
+
 	// build columns
 	var columns []string
 	if state.target_list != nil {

--- a/fdw/common.h
+++ b/fdw/common.h
@@ -67,6 +67,8 @@ typedef struct FdwPlanState
   int width;
   // the number of rows to return (limit+offset). -1 means no limit
   int limit;
+  // OpenTelemetry trace context extracted from session variables
+  char *trace_context_string;
 
 } FdwPlanState;
 

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -120,6 +120,14 @@ static char *extractTraceContextFromSession(void)
     return result;
 }
 
+/*
+ * Public wrapper for extractTraceContextFromSession - callable from Go
+ */
+char *getTraceContextFromSession(void)
+{
+    return extractTraceContextFromSession();
+}
+
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
 {
   FdwPlanState *planstate;

--- a/fdw/fdw_helpers.h
+++ b/fdw/fdw_helpers.h
@@ -106,3 +106,6 @@ static inline char *nameStr(Name n) { return NameStr(*n); }
 
 // logging
 char *tagTypeToString(NodeTag type);
+
+// trace context
+char *getTraceContextFromSession(void);

--- a/hub/hub_base.go
+++ b/hub/hub_base.go
@@ -383,6 +383,13 @@ func (h *hubBase) traceContextForScan(table string, columns []string, limit int6
 		if parentCtx := h.parseTraceContext(traceContextStr); parentCtx != nil {
 			baseCtx = parentCtx
 			log.Printf("[TRACE] Using parent trace context for scan of table: %s", table)
+
+			// Verify the parent context has the expected trace ID
+			parentSpanCtx := trace.SpanContextFromContext(parentCtx)
+			if parentSpanCtx.IsValid() {
+				log.Printf("[DEBUG] Parent context TraceID: %s, SpanID: %s",
+					parentSpanCtx.TraceID().String(), parentSpanCtx.SpanID().String())
+			}
 		} else {
 			log.Printf("[WARN] Failed to parse trace context for table: %s", table)
 		}

--- a/hub/hub_local.go
+++ b/hub/hub_local.go
@@ -128,7 +128,7 @@ func (l *HubLocal) GetIterator(columns []string, quals *proto.Quals, unhandledRe
 	}
 
 	// create a span for this scan
-	scanTraceCtx := l.traceContextForScan(table, columns, limit, qualMap, connectionName)
+	scanTraceCtx := l.traceContextForScan(table, columns, limit, qualMap, connectionName, opts)
 	iterator, err := l.startScanForConnection(connectionName, table, qualMap, unhandledRestrictions, columns, limit, sortOrder, queryTimestamp, scanTraceCtx)
 
 	if err != nil {

--- a/hub/hub_remote.go
+++ b/hub/hub_remote.go
@@ -102,7 +102,7 @@ func (h *RemoteHub) GetIterator(columns []string, quals *proto.Quals, unhandledR
 	}
 
 	// create a span for this scan
-	scanTraceCtx := h.traceContextForScan(table, columns, limit, qualMap, connectionName)
+	scanTraceCtx := h.traceContextForScan(table, columns, limit, qualMap, connectionName, opts)
 	iterator, err := h.startScanForConnection(connectionName, table, qualMap, unhandledRestrictions, columns, limit, sortOrder, queryTimestamp, scanTraceCtx)
 
 	if err != nil {

--- a/hub/trace_context_test.go
+++ b/hub/trace_context_test.go
@@ -1,0 +1,160 @@
+package hub
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// setupTestTracer sets up a test tracer provider and returns a cleanup function
+func setupTestTracer() func() {
+	// Create a tracer provider for testing
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+
+	// Set as global tracer provider
+	otel.SetTracerProvider(tp)
+
+	// Set global propagator
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	// Return cleanup function
+	return func() {
+		_ = tp.Shutdown(context.Background())
+	}
+}
+
+func TestParseTraceContext(t *testing.T) {
+	// Set up test tracer
+	cleanup := setupTestTracer()
+	defer cleanup()
+
+	// Create a hubBase
+	hub := &hubBase{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool // whether valid context should be extracted
+	}{
+		{
+			name:     "Valid traceparent only",
+			input:    "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+			expected: true,
+		},
+		{
+			name:     "Valid traceparent and tracestate",
+			input:    "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01;tracestate=rojo=00f067aa0ba902b7",
+			expected: true,
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "Invalid format",
+			input:    "invalid-trace-context",
+			expected: false,
+		},
+		{
+			name:     "Missing traceparent",
+			input:    "tracestate=rojo=00f067aa0ba902b7",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := hub.parseTraceContext(tt.input)
+			hasValidSpan := ctx != nil && trace.SpanContextFromContext(ctx).IsValid()
+
+			if hasValidSpan != tt.expected {
+				t.Errorf("parseTraceContext() = %v, expected %v for input: %s", hasValidSpan, tt.expected, tt.input)
+			}
+
+			if hasValidSpan {
+				spanCtx := trace.SpanContextFromContext(ctx)
+				t.Logf("Successfully extracted trace context - TraceID: %s, SpanID: %s",
+					spanCtx.TraceID().String(), spanCtx.SpanID().String())
+			}
+		})
+	}
+}
+
+func TestTraceContextForScanWithSessionVariables(t *testing.T) {
+	// Set up test tracer
+	cleanup := setupTestTracer()
+	defer cleanup()
+
+	// Create a hubBase
+	hub := &hubBase{}
+
+	// Test with trace context in options
+	opts := map[string]string{
+		"connection":    "aws",
+		"table":         "aws_s3_bucket",
+		"trace_context": "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}
+
+	traceCtx := hub.traceContextForScan("aws_s3_bucket", []string{"name", "region"}, 10, nil, "aws", opts)
+
+	if traceCtx == nil {
+		t.Fatal("Expected trace context to be created")
+	}
+
+	if traceCtx.Span == nil {
+		t.Fatal("Expected span to be created")
+	}
+
+	// Verify that the span has a valid context
+	spanCtx := traceCtx.Span.SpanContext()
+	if !spanCtx.IsValid() {
+		t.Fatal("Expected span context to be valid")
+	}
+
+	t.Logf("Created span with TraceID: %s, SpanID: %s",
+		spanCtx.TraceID().String(), spanCtx.SpanID().String())
+}
+
+func TestTraceContextForScanWithoutSessionVariables(t *testing.T) {
+	// Set up test tracer
+	cleanup := setupTestTracer()
+	defer cleanup()
+
+	// Create a hubBase
+	hub := &hubBase{}
+
+	// Test without trace context in options
+	opts := map[string]string{
+		"connection": "aws",
+		"table":      "aws_s3_bucket",
+	}
+
+	traceCtx := hub.traceContextForScan("aws_s3_bucket", []string{"name", "region"}, 10, nil, "aws", opts)
+
+	if traceCtx == nil {
+		t.Fatal("Expected trace context to be created")
+	}
+
+	if traceCtx.Span == nil {
+		t.Fatal("Expected span to be created")
+	}
+
+	// Verify that the span has a valid context (should be a new root span)
+	spanCtx := traceCtx.Span.SpanContext()
+	if !spanCtx.IsValid() {
+		t.Fatal("Expected span context to be valid")
+	}
+
+	t.Logf("Created root span with TraceID: %s, SpanID: %s",
+		spanCtx.TraceID().String(), spanCtx.SpanID().String())
+}

--- a/types/pathkeys_test.go
+++ b/types/pathkeys_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 )
 
-
 func TestKeyColumnsToPathKeys(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
This PR allows forwarding OpenTelemetry context from clients to Steampipe FDW.

From client perspective, it can be used like this (python with psycopg):
```python
import logging

import psycopg

from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator

logger = logging.getLogger(__name__)

steampipe_conn = psycopg.connect(
    host="127.0.0.1",
    dbname="steampipe",
    user="steampipe",
    port="9193",
    password="steampipe",
    autocommit=True,
)

trace_context = {}
TraceContextTextMapPropagator().inject(trace_context)
if traceparent := trace_context.get("traceparent"):
    logger.debug("Propagating OpenTelemetry traceparent: %s", traceparent)
    steampipe_conn.execute(f"SET steampipe.traceparent = '{traceparent}'")

    if tracestate := trace_context.get("tracestate"):
        logger.debug("Propagating OpenTelemetry tracestate=%s", tracestate)
        steampipe_conn.execute(f"SET steampipe.tracestate = '{tracestate}'")

steampipe_conn.execute("SELECT account_id FROM aws_account")
steampipe_conn.execute("SELECT arn FROM aws_health_event")
```


When traces are ingested in an OpenTelemetry compatible solution such as Google Cloud Tracing, traces are properly grouped, e.g.:

![image](https://github.com/user-attachments/assets/153fc846-9a73-4406-b700-44050bee2c1e)
