### PR TITLE
feat: support propagation of OpenTelemetry context from clients with SQLcommenter

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -323,7 +323,7 @@ func goFdwBeginForeignScan(node *C.ForeignScanState, eflags C.int) {
 
 	// Extract trace context from session variables for scan operation
 	var traceContext string
-	if traceContextPtr := C.getTraceContextFromSession(); traceContextPtr != nil {
+	if traceContextPtr := C.getTraceContext(); traceContextPtr != nil {
 		traceContext = C.GoString(traceContextPtr)
 		log.Printf("[TRACE] Extracted trace context from session for scan: %s", traceContext)
 	} else {

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -6,6 +6,7 @@
 #include "access/xact.h"
 #include "utils/guc.h"
 #include "utils/builtins.h"
+#include "tcop/tcopprot.h"
 
 extern PGDLLEXPORT void _PG_init(void);
 
@@ -15,6 +16,11 @@ static char *convertUUID(char *uuid);
 
 static void pgfdw_xact_callback(XactEvent event, void *arg);
 static void exitHook(int code, Datum arg);
+
+/* Trace context extraction functions */
+static char *extractTraceContextFromSession(void);
+static char *extractTraceContextFromQueryComments(void);
+static char *extractTraceContext(void);
 
 void *serializePlanState(FdwPlanState *state);
 FdwExecState *initializeExecState(void *internalstate);
@@ -103,7 +109,7 @@ static char *extractTraceContextFromSession(void)
     const char *traceparent = GetConfigOption("steampipe.traceparent", true, false);
     const char *tracestate = GetConfigOption("steampipe.tracestate", true, false);
     char *result = NULL;
-    
+
     // Format the result string for Go layer consumption
     if (traceparent != NULL) {
         if (tracestate != NULL) {
@@ -111,21 +117,146 @@ static char *extractTraceContextFromSession(void)
         } else {
             result = psprintf("traceparent=%s", traceparent);
         }
-        
+
         elog(DEBUG1, "extracted trace context: %s", result);
     } else {
         elog(DEBUG2, "no trace context found in session variables");
     }
-    
+
     return result;
 }
 
 /*
- * Public wrapper for extractTraceContextFromSession - callable from Go
+ * Extract OpenTelemetry trace context from SQL query comments (SQLcommenter format)
+ * Parses comments like: /*traceparent='00-...',tracestate='rojo=...'*\/
+ * Returns a formatted string containing traceparent and tracestate, or NULL if not found
  */
-char *getTraceContextFromSession(void)
+static char *extractTraceContextFromQueryComments(void)
 {
-    return extractTraceContextFromSession();
+    const char *query_string = debug_query_string;
+    char *result = NULL;
+    char *traceparent = NULL;
+    char *tracestate = NULL;
+
+    if (query_string == NULL) {
+        elog(DEBUG2, "no query string available for SQLcommenter parsing");
+        return NULL;
+    }
+
+    elog(DEBUG2, "parsing SQLcommenter from query: %.100s...", query_string);
+
+    // Look for SQL comments in the format /*...*/
+    const char *comment_start = strstr(query_string, "/*");
+    while (comment_start != NULL) {
+        const char *comment_end = strstr(comment_start, "*/");
+        if (comment_end == NULL) {
+            break; // Malformed comment, skip
+        }
+
+        // Extract the comment content
+        size_t comment_len = comment_end - comment_start - 2; // Exclude /* and */
+        char *comment_content = palloc(comment_len + 1);
+        strncpy(comment_content, comment_start + 2, comment_len);
+        comment_content[comment_len] = '\0';
+
+        elog(DEBUG2, "found SQL comment: %s", comment_content);
+
+        // Parse key-value pairs in the comment
+        char *token = strtok(comment_content, ",");
+        while (token != NULL) {
+            // Trim whitespace
+            while (*token == ' ' || *token == '\t') token++;
+
+            // Look for traceparent or tracestate
+            if (strncmp(token, "traceparent=", 12) == 0) {
+                char *value = token + 12;
+                // Remove quotes if present
+                if (*value == '\'' || *value == '"') {
+                    char quote_char = *value;
+                    value++;
+                    char *end_quote = strrchr(value, quote_char);
+                    if (end_quote) *end_quote = '\0';
+                }
+                if (traceparent) pfree(traceparent);
+                traceparent = pstrdup(value);
+                elog(DEBUG2, "extracted traceparent from SQLcommenter: %s", traceparent);
+            } else if (strncmp(token, "tracestate=", 11) == 0) {
+                char *value = token + 11;
+                // Remove quotes if present
+                if (*value == '\'' || *value == '"') {
+                    char quote_char = *value;
+                    value++;
+                    char *end_quote = strrchr(value, quote_char);
+                    if (end_quote) *end_quote = '\0';
+                }
+                if (tracestate) pfree(tracestate);
+                tracestate = pstrdup(value);
+                elog(DEBUG2, "extracted tracestate from SQLcommenter: %s", tracestate);
+            }
+
+            token = strtok(NULL, ",");
+        }
+
+        pfree(comment_content);
+
+        // Look for next comment
+        comment_start = strstr(comment_end + 2, "/*");
+    }
+
+    // Format the result string for Go layer consumption
+    if (traceparent != NULL) {
+        if (tracestate != NULL) {
+            result = psprintf("traceparent=%s;tracestate=%s", traceparent, tracestate);
+        } else {
+            result = psprintf("traceparent=%s", traceparent);
+        }
+
+        elog(DEBUG1, "extracted trace context from SQLcommenter: %s", result);
+    } else {
+        elog(DEBUG2, "no trace context found in SQL comments");
+    }
+
+    // Clean up
+    if (traceparent) pfree(traceparent);
+    if (tracestate) pfree(tracestate);
+
+    return result;
+}
+
+/*
+ * Extract trace context with fallback strategy:
+ * 1. Try PostgreSQL session variables first
+ * 2. Fall back to SQLcommenter in query comments
+ * 3. Return NULL if neither found
+ */
+static char *extractTraceContext(void)
+{
+    char *result = NULL;
+
+    // First try session variables (primary method)
+    result = extractTraceContextFromSession();
+    if (result != NULL) {
+        elog(DEBUG1, "using trace context from session variables");
+        return result;
+    }
+
+    // Fall back to SQLcommenter (secondary method)
+    result = extractTraceContextFromQueryComments();
+    if (result != NULL) {
+        elog(DEBUG1, "using trace context from SQLcommenter");
+        return result;
+    }
+
+    elog(DEBUG2, "no trace context found in session variables or SQLcommenter");
+    return NULL;
+}
+
+/*
+ * Public wrapper for extractTraceContext - callable from Go
+ */
+char *getTraceContext(void)
+{
+    return extractTraceContext();
 }
 
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid)
@@ -147,9 +278,9 @@ static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid for
   // Save plan state information
   baserel->fdw_private = planstate;
   planstate->foreigntableid = foreigntableid;
-  
-  // Extract trace context from session variables
-  char *traceContext = extractTraceContextFromSession();
+
+  // Extract trace context with fallback strategy (session variables -> SQLcommenter)
+  char *traceContext = extractTraceContext();
   if (traceContext != NULL) {
       planstate->trace_context_string = pstrdup(traceContext);
       pfree(traceContext);

--- a/fdw/fdw_helpers.h
+++ b/fdw/fdw_helpers.h
@@ -108,4 +108,4 @@ static inline char *nameStr(Name n) { return NameStr(*n); }
 char *tagTypeToString(NodeTag type);
 
 // trace context
-char *getTraceContextFromSession(void);
+char *getTraceContext(void);

--- a/hub/trace_context_test.go
+++ b/hub/trace_context_test.go
@@ -45,16 +45,44 @@ func TestParseTraceContext(t *testing.T) {
 		input    string
 		expected bool // whether valid context should be extracted
 	}{
+		// Session variable format tests
 		{
-			name:     "Valid traceparent only",
+			name:     "Session variables: Valid traceparent only",
 			input:    "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 			expected: true,
 		},
 		{
-			name:     "Valid traceparent and tracestate",
+			name:     "Session variables: Valid traceparent and tracestate",
 			input:    "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01;tracestate=rojo=00f067aa0ba902b7",
 			expected: true,
 		},
+		// SQLcommenter format tests
+		{
+			name:     "SQLcommenter: Valid traceparent only with single quotes",
+			input:    "traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'",
+			expected: true,
+		},
+		{
+			name:     "SQLcommenter: Valid traceparent and tracestate with single quotes",
+			input:    "traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',tracestate='rojo=00f067aa0ba902b7'",
+			expected: true,
+		},
+		{
+			name:     "SQLcommenter: Valid traceparent and tracestate with double quotes",
+			input:    "traceparent=\"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\",tracestate=\"rojo=00f067aa0ba902b7\"",
+			expected: true,
+		},
+		{
+			name:     "SQLcommenter: Mixed with other attributes",
+			input:    "application='myapp',traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',tracestate='rojo=00f067aa0ba902b7'",
+			expected: true,
+		},
+		{
+			name:     "SQLcommenter: No quotes",
+			input:    "traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,tracestate=rojo=00f067aa0ba902b7",
+			expected: true,
+		},
+		// Error cases
 		{
 			name:     "Empty string",
 			input:    "",
@@ -66,8 +94,13 @@ func TestParseTraceContext(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "Missing traceparent",
+			name:     "Missing traceparent (session variable format)",
 			input:    "tracestate=rojo=00f067aa0ba902b7",
+			expected: false,
+		},
+		{
+			name:     "Missing traceparent (SQLcommenter format)",
+			input:    "tracestate='rojo=00f067aa0ba902b7'",
 			expected: false,
 		},
 	}
@@ -157,4 +190,90 @@ func TestTraceContextForScanWithoutSessionVariables(t *testing.T) {
 
 	t.Logf("Created root span with TraceID: %s, SpanID: %s",
 		spanCtx.TraceID().String(), spanCtx.SpanID().String())
+}
+
+func TestTraceContextForScanWithSQLcommenter(t *testing.T) {
+	// Set up test tracer
+	cleanup := setupTestTracer()
+	defer cleanup()
+
+	// Create a hubBase
+	hub := &hubBase{}
+
+	// Test with SQLcommenter format trace context in options
+	opts := map[string]string{
+		"connection":    "aws",
+		"table":         "aws_s3_bucket",
+		"trace_context": "traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',tracestate='rojo=00f067aa0ba902b7'",
+	}
+
+	traceCtx := hub.traceContextForScan("aws_s3_bucket", []string{"name", "region"}, 10, nil, "aws", opts)
+
+	if traceCtx == nil {
+		t.Fatal("Expected trace context to be created")
+	}
+
+	if traceCtx.Span == nil {
+		t.Fatal("Expected span to be created")
+	}
+
+	// Verify that the span has a valid context
+	spanCtx := traceCtx.Span.SpanContext()
+	if !spanCtx.IsValid() {
+		t.Fatal("Expected span context to be valid")
+	}
+
+	t.Logf("Created span with SQLcommenter format - TraceID: %s, SpanID: %s",
+		spanCtx.TraceID().String(), spanCtx.SpanID().String())
+}
+
+func TestParseTraceContextSQLcommenterFormats(t *testing.T) {
+	// Set up test tracer
+	cleanup := setupTestTracer()
+	defer cleanup()
+
+	// Create a hubBase
+	hub := &hubBase{}
+
+	sqlcommenterTests := []struct {
+		name        string
+		input       string
+		description string
+	}{
+		{
+			name:        "Basic SQLcommenter with single quotes",
+			input:       "traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'",
+			description: "Basic traceparent only with single quotes",
+		},
+		{
+			name:        "SQLcommenter with both traceparent and tracestate",
+			input:       "traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',tracestate='rojo=00f067aa0ba902b7'",
+			description: "Both traceparent and tracestate with single quotes",
+		},
+		{
+			name:        "SQLcommenter with double quotes",
+			input:       "traceparent=\"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\",tracestate=\"rojo=00f067aa0ba902b7\"",
+			description: "Both traceparent and tracestate with double quotes",
+		},
+		{
+			name:        "SQLcommenter mixed with other attributes",
+			input:       "application='myapp',traceparent='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',tracestate='rojo=00f067aa0ba902b7',controller='users'",
+			description: "Trace context mixed with other SQLcommenter attributes",
+		},
+	}
+
+	for _, tt := range sqlcommenterTests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := hub.parseTraceContext(tt.input)
+			hasValidSpan := ctx != nil && trace.SpanContextFromContext(ctx).IsValid()
+
+			if !hasValidSpan {
+				t.Errorf("parseTraceContext() failed to extract valid context from SQLcommenter format: %s", tt.input)
+			} else {
+				spanCtx := trace.SpanContextFromContext(ctx)
+				t.Logf("Successfully extracted SQLcommenter trace context (%s) - TraceID: %s, SpanID: %s",
+					tt.description, spanCtx.TraceID().String(), spanCtx.SpanID().String())
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR is based on the branch from https://github.com/turbot/steampipe-postgres-fdw/pull/568 and only adds commit https://github.com/turbot/steampipe-postgres-fdw/commit/205fa75533d9e10076c0d8e0e7414c52a33879e4 to add support for propagating OpenTelemetry trace context with SQLcommenter which simplifies greatly usage:

```
import logging

import psycopg

from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor

logger = logging.getLogger(__name__)

steampipe_conn = psycopg.connect(
    host="127.0.0.1",
    dbname="steampipe",
    user="steampipe",
    port="9193",
    password="steampipe",
    autocommit=True,
)

# Instrument psycopg with SQLcommenter enabled
PsycopgInstrumentor().instrument(enable_commenter=True)

steampipe_conn.execute("SELECT account_id FROM aws_account")
steampipe_conn.execute("SELECT arn FROM aws_health_event")
```