### PR TITLE
sql: add schema descriptions as table and column comments

### DIFF
--- a/fdw/common.h
+++ b/fdw/common.h
@@ -13,6 +13,7 @@
 #include "nodes/bitmapset.h"
 #include "nodes/makefuncs.h"
 #include "nodes/pg_list.h"
+#include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/inet.h"
 #include "utils/jsonb.h"

--- a/fdw/fdw_handlers.h
+++ b/fdw/fdw_handlers.h
@@ -2,6 +2,8 @@
 // defined and available.
 #include "fmgr.h"
 
+#define STEAMPIPE_DATAWRAPPER_NAME "steampipe_postgres_fdw"
+
 static bool fdwIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte);
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);

--- a/schema.go
+++ b/schema.go
@@ -71,3 +71,25 @@ func SchemaToSql(schema map[string]*proto.TableSchema, stmt *C.ImportForeignSche
 
 	return commands
 }
+
+func SchemaToCommentsSql(localSchema, table string, tableSchema *proto.TableSchema) *C.List {
+	if tableSchema == nil {
+		return nil
+	}
+
+	log.Printf("[TRACE] Getting comments for table %s", table)
+
+	comments, err := sql.GetCommentsForTable(table, tableSchema, localSchema)
+	if err != nil {
+		FdwError(err)
+		return nil
+	}
+
+	var commands *C.List
+	for _, c := range comments {
+		log.Printf("[TRACE] SQL %s", c)
+		commands = C.lappend(commands, unsafe.Pointer(C.CString(c)))
+	}
+
+	return commands
+}

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -45,6 +45,27 @@ SERVER %s OPTIONS (table %s)`,
 	return sql, nil
 }
 
+func GetCommentsForTable(table string, tableSchema *proto.TableSchema, localSchema string) ([]string, error) {
+	localSchema = db_common.PgEscapeName(localSchema)
+	table = db_common.PgEscapeName(table)
+
+	var commentStatements []string
+	if tableSchema.Description != "" {
+		tableDescription := db_common.PgEscapeString(tableSchema.Description)
+		commentStatements = append(commentStatements, fmt.Sprintf("COMMENT ON FOREIGN TABLE %s.%s IS %s", localSchema, table, tableDescription))
+	}
+
+	for _, c := range tableSchema.Columns {
+		if c.Description != "" {
+			column := db_common.PgEscapeName(c.Name)
+			columnDescription := db_common.PgEscapeString(c.Description)
+			commentStatements = append(commentStatements, fmt.Sprintf("COMMENT ON COLUMN %s.%s.%s IS %s", localSchema, table, column, columnDescription))
+		}
+	}
+
+	return commentStatements, nil
+}
+
 func sqlTypeForColumnType(columnType proto.ColumnType) (string, error) {
 	switch columnType {
 	case proto.ColumnType_BOOL:

--- a/templates/fdw/fdw_handlers.h.tmpl
+++ b/templates/fdw/fdw_handlers.h.tmpl
@@ -2,6 +2,8 @@
 // defined and available.
 #include "fmgr.h"
 
+#define STEAMPIPE_DATAWRAPPER_NAME "steampipe_postgres_{{.Plugin}}"
+
 static void fdwGetForeignRelSize(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid);
 static ForeignScan *fdwGetForeignPlan(


### PR DESCRIPTION
The steampipe CLI does this, and it's very helpful when trying to figure out what a specific table or column holds.