### PR TITLE
fix: OpenTelemetry metric names must only contain [A-Za-z0-9_.-]

### DIFF
--- a/hub/hub_base.go
+++ b/hub/hub_base.go
@@ -551,7 +551,7 @@ func (h *hubBase) initialiseTelemetry() error {
 	h.telemetryShutdownFunc = shutdownTelemetry
 
 	hydrateCalls, err := otel.GetMeterProvider().Meter(FdwName).Int64Counter(
-		fmt.Sprintf("%s/hydrate_calls_total", FdwName),
+		fmt.Sprintf("%s-hydrate_calls_total", FdwName),
 		metric.WithDescription("The total number of hydrate calls"),
 	)
 	if err != nil {


### PR DESCRIPTION
Somehow, the changes from https://github.com/turbot/steampipe-postgres-fdw/pull/369 was lost.

The commit that removed this is https://github.com/turbot/steampipe-postgres-fdw/commit/7d4a28a3590382cd98f71b5bbe6f335039841390