### PR TITLE
Harden GitHub Actions: set explicit permissions

### DIFF
--- a/.github/workflows/add-issues-to-pipeling-issue-tracker.yaml
+++ b/.github/workflows/add-issues-to-pipeling-issue-tracker.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-pipeling-issue-tracker.yml@main

--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 env:
   PROJECT_ID: steampipe
   IMAGE_NAME: fdw

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
         description: "The published release to package as an image(must be prefixed with 'v')"
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   PROJECT_ID: steampipe
   IMAGE_NAME: fdw

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: FDW Acceptance Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci_lint:    
     name: golangci-lint


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.