### PR TITLE
Update Go version to 1.26.1 and harden GitHub Actions

### DIFF
--- a/.github/workflows/add-issues-to-pipeling-issue-tracker.yaml
+++ b/.github/workflows/add-issues-to-pipeling-issue-tracker.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-pipeling-issue-tracker.yml@main

--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -67,47 +67,47 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-          
+
       - name: make clean
         run: |-
           go version
-          
+
           which pg_config
           pg_config --version
-          
+
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
-      
+
           export SERVER_LIB=$(pg_config --includedir)/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
           export PG_CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
-      
+
           export LDFLAGS=$(pg_config --ldfalgs)
           export PG_LDFLAGS=$(pg_config --ldfalgs)
-        
+
           make clean
 
       - name: make
         run: |-
           go version
-          
+
           which pg_config
           pg_config --version
-          
+
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
-      
+
           export SERVER_LIB=$(pg_config --includedir)/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
           export PG_CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
-      
+
           export LDFLAGS=$(pg_config --ldfalgs)
           export PG_LDFLAGS=$(pg_config --ldfalgs)
-          
+
           make
 
       - name: gzip the steampipe_postgres_fdw.so
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -186,47 +186,47 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-          
+
       - name: make clean
         run: |-
           go version
-          
+
           which pg_config
           pg_config --version
-          
+
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
-      
+
           export SERVER_LIB=$(pg_config --includedir)/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
           export PG_CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
-      
+
           export LDFLAGS=$(pg_config --ldfalgs)
           export PG_LDFLAGS=$(pg_config --ldfalgs)
-        
+
           make clean
 
       - name: make
         run: |-
           go version
-          
+
           which pg_config
           pg_config --version
-          
+
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
-      
+
           export SERVER_LIB=$(pg_config --includedir)/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
           export PG_CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
-      
+
           export LDFLAGS=$(pg_config --ldfalgs)
           export PG_LDFLAGS=$(pg_config --ldfalgs)
-          
+
           make
 
       - name: gzip the steampipe_postgres_fdw.so
@@ -251,7 +251,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -336,7 +336,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths

--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 env:
   PROJECT_ID: steampipe
   IMAGE_NAME: fdw

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
         description: "The published release to package as an image(must be prefixed with 'v')"
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   PROJECT_ID: steampipe
   IMAGE_NAME: fdw

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: FDW Acceptance Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci_lint:    
     name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26
+          go-version: 1.26.1
 
       - name: Checkout Steampipe
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-postgres-fdw/v2
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/dgraph-io/ristretto v0.2.0 // indirect


### PR DESCRIPTION
## Summary

- Cherry-picks GitHub Actions hardening commit from `develop` (pin actions to SHAs, set explicit permissions) (#644)
- Updates Go version from `1.26` to `1.26.1` in `go.mod`, `buildimage.yml`, and `test.yml` to address a security vulnerability in Go 1.26

## Changes

- `.github/workflows/buildimage.yml` — Go 1.26 → 1.26.1
- `.github/workflows/test.yml` — Go 1.26 → 1.26.1
- `go.mod` — Go 1.26.0 → 1.26.1
- GitHub Actions workflow hardening (pinned action SHAs + explicit permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)