### PR TITLE
Fix publish.yml permissions: contents write for tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:


### PR DESCRIPTION
Same root cause as powerpipe/steampipe release breakage: org-wide default GITHUB_TOKEN was changed to read, and publish.yml declares contents: read. This blocks tag pushes when releasing FDW. Flips contents to write.