### PR TITLE
Bump github.com/jackc/pgx/v5 to v5.9.2 (CVE-2026-41889)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgx/v5 v5.7.3 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1038,8 +1038,8 @@ github.com/jackc/pgproto3/v2 v2.3.3 h1:1HLSx5H+tXR9pW3in3zaztoEwQYRC9SQaYUHjTSUO
 github.com/jackc/pgproto3/v2 v2.3.3/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.3 h1:PO1wNKj/bTAwxSJnO1Z4Ai8j4magtqg2SLNjEDzcXQo=
-github.com/jackc/pgx/v5 v5.7.3/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
## Summary

Bumps `github.com/jackc/pgx/v5` from v5.7.3 to **v5.9.2** to remediate **CVE-2026-41889** (GHSA-j88v-2chj-qfwx), fixed in pgx v5.9.2.

pgx enters the FDW build graph only transitively (`hub` -> `steampipe/v2/pkg/steampipeconfig` -> pgx); no FDW-owned code imports pgx. An explicit `// indirect` pin at v5.9.2 is retained in `go.mod` so the FDW artifact asserts the security floor on its own (Vanta scans this artifact directly, independent of what the upstream `steampipe/v2` / `pipe-fittings/v2` requires resolve to).

- `go get github.com/jackc/pgx/v5@v5.9.2 && go mod tidy`
- Only `go.mod` + `go.sum` changed (pgx v5.7.3 -> v5.9.2). No code changes — risk is compile-only per the reachability analysis.

## Validation

- All non-CGo packages (including `hub`, the only pgx-reachable package) build clean at v5.9.2; `hub` tests pass.
- The root CGo FDW package requires the CI Ubuntu + PGXS Postgres build path and is not buildable in a local macOS env; this is environmental and identical at v5.7.3 and v5.9.2 (verified). The pre-existing `go vet` and `sql` test failures on this base reproduce identically on the unmodified base and are unrelated to this bump.

Trunk fix. The `v2.2.x` release-line backport is in #663. Fixes #662.
