### PR TITLE
Add PostgreSQL 18 build support (v2.2.3)

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -21,8 +21,10 @@ jobs:
     name: Build for Darwin x86_64
     runs-on: macos-15-intel
     steps:
-      - name: Install PostgreSQL@14
-        run: brew install --force postgresql@14
+      - name: Install PostgreSQL@18
+        run: |-
+          brew install --force postgresql@18
+          echo "$(brew --prefix postgresql@18)/bin" >> "$GITHUB_PATH"
 
       - name: PGConfig
         run: |-
@@ -112,6 +114,7 @@ jobs:
 
       - name: gzip the steampipe_postgres_fdw.so
         run: |-
+          if [ -f build-Darwin/steampipe_postgres_fdw.dylib ]; then mv build-Darwin/steampipe_postgres_fdw.dylib build-Darwin/steampipe_postgres_fdw.so; fi
           gzip build-Darwin/steampipe_postgres_fdw.so
           mv build-Darwin/steampipe_postgres_fdw.so.gz build-Darwin/steampipe_postgres_fdw.so.darwin_amd64.gz
 
@@ -140,8 +143,10 @@ jobs:
     name: Build for Darwin ARM64
     runs-on: macos-latest
     steps:
-      - name: Install PostgreSQL@14
-        run: brew install --force postgresql@14
+      - name: Install PostgreSQL@18
+        run: |-
+          brew install --force postgresql@18
+          echo "$(brew --prefix postgresql@18)/bin" >> "$GITHUB_PATH"
 
       - name: PGConfig
         run: |-
@@ -231,6 +236,7 @@ jobs:
 
       - name: gzip the steampipe_postgres_fdw.so
         run: |-
+          if [ -f build-Darwin/steampipe_postgres_fdw.dylib ]; then mv build-Darwin/steampipe_postgres_fdw.dylib build-Darwin/steampipe_postgres_fdw.so; fi
           gzip build-Darwin/steampipe_postgres_fdw.so
           mv build-Darwin/steampipe_postgres_fdw.so.gz build-Darwin/steampipe_postgres_fdw.so.darwin_arm64.gz
 
@@ -280,9 +286,9 @@ jobs:
           sudo env ACCEPT_EULA=Y apt-get update
           sudo env ACCEPT_EULA=Y apt-get upgrade
 
-      - name: Install PostgreSQL14 Dev
+      - name: Install PostgreSQL18 Dev
         run: |-
-          sudo apt-get -y install postgresql-server-dev-14
+          sudo apt-get -y install postgresql-server-dev-18
 
       - name: Find stuff and set env
         run: |-
@@ -293,7 +299,7 @@ jobs:
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
       
-          export SERVER_LIB=$(pg_config --includedir)/14/server
+          export SERVER_LIB=$(pg_config --includedir)/18/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"
@@ -365,9 +371,9 @@ jobs:
           sudo env ACCEPT_EULA=Y apt-get update
           sudo env ACCEPT_EULA=Y apt-get upgrade
 
-      - name: Install PostgreSQL14 Dev
+      - name: Install PostgreSQL18 Dev
         run: |-
-          sudo apt-get -y install postgresql-server-dev-14
+          sudo apt-get -y install postgresql-server-dev-18
 
       - name: Find stuff and set env
         run: |-
@@ -378,7 +384,7 @@ jobs:
           export PATH=$(pg_config --bindir):$PATH
           export PGXS=$(pg_config --pgxs)
       
-          export SERVER_LIB=$(pg_config --includedir)/14/server
+          export SERVER_LIB=$(pg_config --includedir)/18/server
           export INTERNAL_LIB=$(pg_config --includedir)/internal
 
           export CFLAGS="$(pg_config --cflags) -I${SERVER_LIB} -I${INTERNAL_LIB} -g"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v2.3.0 [2026-06-10]
 _Whats new_
-- Add support for building against PostgreSQL 18. Three localized, version-guarded source changes (`#if PG_VERSION_NUM >= 180000`): include `commands/explain_format.h` (PG18 EXPLAIN header split), use `PathKey.pk_cmptype`/`COMPARE_GT` (renamed from `pk_strategy`/`BTGreaterStrategyNumber`), and pass the new `disabled_nodes` and `fdw_restrictinfo` arguments to `create_foreignscan_path`. Behaviour on PostgreSQL 16 and earlier is unchanged.
+- Add support for building against PostgreSQL 18. Localized, version-guarded source changes: include `commands/explain_format.h` (PG18 EXPLAIN header split) and use `PathKey.pk_cmptype`/`COMPARE_GT` instead of `pk_strategy`/`BTGreaterStrategyNumber` (both `#if PG_VERSION_NUM >= 180000`); and pass the extra `create_foreignscan_path` arguments — `fdw_restrictinfo` (added in PostgreSQL 17, `#if PG_VERSION_NUM >= 170000`) and `disabled_nodes` (added in PostgreSQL 18, `#if PG_VERSION_NUM >= 180000`). Behaviour on PostgreSQL 16 and earlier is unchanged.
 
 ## v2.2.4 [2026-05-25]
 _Bug fixes_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.3.0 [2026-06-10]
+_Whats new_
+- Add support for building against PostgreSQL 18. Three localized, version-guarded source changes (`#if PG_VERSION_NUM >= 180000`): include `commands/explain_format.h` (PG18 EXPLAIN header split), use `PathKey.pk_cmptype`/`COMPARE_GT` (renamed from `pk_strategy`/`BTGreaterStrategyNumber`), and pass the new `disabled_nodes` and `fdw_restrictinfo` arguments to `create_foreignscan_path`. Behaviour on PostgreSQL 16 and earlier is unchanged.
+
 ## v2.2.4 [2026-05-25]
 _Bug fixes_
 - Fix `statement_timeout`, `pg_cancel_backend`, and `pg_terminate_backend` having no effect when a plugin's gRPC stream stalls — a hung scan held `AccessShareLock` indefinitely, blocking partition swaps and other DDL until restart. ([#671](https://github.com/turbot/steampipe-postgres-fdw/issues/671), [#672](https://github.com/turbot/steampipe-postgres-fdw/pull/672))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.3.0 [2026-06-10]
 _Whats new_
 - Add support for building against PostgreSQL 18. Localized, version-guarded source changes: include `commands/explain_format.h` (PG18 EXPLAIN header split) and use `PathKey.pk_cmptype`/`COMPARE_GT` instead of `pk_strategy`/`BTGreaterStrategyNumber` (both `#if PG_VERSION_NUM >= 180000`); and pass the extra `create_foreignscan_path` arguments — `fdw_restrictinfo` (added in PostgreSQL 17, `#if PG_VERSION_NUM >= 170000`) and `disabled_nodes` (added in PostgreSQL 18, `#if PG_VERSION_NUM >= 180000`). Behaviour on PostgreSQL 16 and earlier is unchanged.
+- Handle nested `RestrictInfo` nodes in `pull_var_clause` on PostgreSQL 18 — multi-table JOINs on foreign tables failed with `unrecognized node type: 318` without this. (`#if PG_VERSION_NUM >= 180000`; no change on earlier versions.)
 
 ## v2.2.4 [2026-05-25]
 _Bug fixes_

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -58,11 +58,11 @@ inst:
 	mkdir -p ../build-${PLATFORM}
 	rm -f ../build-${PLATFORM}/*
 
-	cp steampipe_postgres_fdw.so ../build-${PLATFORM}
+	@if [ -f steampipe_postgres_fdw.dylib ]; then cp steampipe_postgres_fdw.dylib ../build-${PLATFORM}/steampipe_postgres_fdw.so; else cp steampipe_postgres_fdw.so ../build-${PLATFORM}/steampipe_postgres_fdw.so; fi
 	cp steampipe_postgres_fdw.control ../build-${PLATFORM}
 	cp steampipe_postgres_fdw--1.0.sql ../build-${PLATFORM}
-	
-	rm steampipe_postgres_fdw.so
+
+	rm -f steampipe_postgres_fdw.so steampipe_postgres_fdw.dylib
 	rm steampipe_postgres_fdw.a
 	rm steampipe_postgres_fdw.h
 	

--- a/fdw/common.h
+++ b/fdw/common.h
@@ -6,6 +6,10 @@
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "commands/explain.h"
+#if PG_VERSION_NUM >= 180000
+/* PG18 moved the EXPLAIN property-output API into a separate header */
+#include "commands/explain_format.h"
+#endif
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
 #include "funcapi.h"

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -444,8 +444,8 @@ static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid forei
                              NIL,                                                /* no pathkeys */
                              NULL,
                              NULL,
-#if PG_VERSION_NUM >= 180000
-                             NIL, /* fdw_restrictinfo (PG18) */
+#if PG_VERSION_NUM >= 170000
+                             NIL, /* fdw_restrictinfo (added in PG17) */
 #endif
                               (void *)fdw_private));
 
@@ -470,8 +470,8 @@ static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid forei
           path->path.startup_cost, path->path.total_cost,
           apply_pathkeys, NULL,
           NULL,
-#if PG_VERSION_NUM >= 180000
-          NIL, /* fdw_restrictinfo (PG18) */
+#if PG_VERSION_NUM >= 170000
+          NIL, /* fdw_restrictinfo (added in PG17) */
 #endif
           (void *)fdw_private);
       newpath->path.param_info = path->path.param_info;

--- a/fdw/fdw.c
+++ b/fdw/fdw.c
@@ -436,11 +436,17 @@ static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid forei
                              baserel,
                              NULL, /* default pathtarget */
                              baserel->rows,
+#if PG_VERSION_NUM >= 180000
+                             0, /* disabled_nodes (PG18) */
+#endif
                              planstate->startupCost,
                              baserel->rows * baserel->reltarget->width * 100000, // table scan is very expensive
                              NIL,                                                /* no pathkeys */
                              NULL,
                              NULL,
+#if PG_VERSION_NUM >= 180000
+                             NIL, /* fdw_restrictinfo (PG18) */
+#endif
                               (void *)fdw_private));
 
   /* Add each ForeignPath previously found */
@@ -458,9 +464,15 @@ static void fdwGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid forei
           baserel,
           NULL, /* default pathtarget */
           path->path.rows,
+#if PG_VERSION_NUM >= 180000
+          0, /* disabled_nodes (PG18) */
+#endif
           path->path.startup_cost, path->path.total_cost,
           apply_pathkeys, NULL,
           NULL,
+#if PG_VERSION_NUM >= 180000
+          NIL, /* fdw_restrictinfo (PG18) */
+#endif
           (void *)fdw_private);
       newpath->path.param_info = path->path.param_info;
       add_path(baserel, (Path *)newpath);

--- a/fdw/query.c
+++ b/fdw/query.c
@@ -13,6 +13,7 @@
 #include "catalog/pg_operator.h"
 #include "mb/pg_wchar.h"
 #include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
 #include "utils/lsyscache.h"
 #include "miscadmin.h"
 #include "parser/parsetree.h"
@@ -22,6 +23,34 @@
 /* Third argument to get_attname was introduced in [8237f27] (release 11) */
 #if PG_VERSION_NUM >= 110000
 #define get_attname(x, y) get_attname(x, y, true)
+#endif
+
+#if PG_VERSION_NUM >= 180000
+/*
+ * PG18 dropped the T_RestrictInfo case from expression_tree_walker
+ * (src/backend/nodes/nodeFuncs.c). When the FDW walks a clause subtree
+ * that contains a nested RestrictInfo (the orclause cache, certain
+ * join-equivalence-class derived predicates), the walker hits the
+ * unrecognized node tag (318) and elogs
+ * "unrecognized node type: 318". Restore the PG<=17 behaviour with a
+ * pre-pass mutator that replaces each RestrictInfo with its wrapped
+ * clause before pull_var_clause's walker sees it.
+ */
+static Node *
+strip_restrictinfo_mutator(Node *node, void *context)
+{
+    if (node == NULL)
+        return NULL;
+    if (IsA(node, RestrictInfo))
+        return strip_restrictinfo_mutator(
+            (Node *) ((RestrictInfo *) node)->clause, context);
+    return expression_tree_mutator(node, strip_restrictinfo_mutator, context);
+}
+#define PULL_VAR_CLAUSE_PG18_SAFE(node, flags) \
+    pull_var_clause(strip_restrictinfo_mutator((node), NULL), (flags))
+#else
+#define PULL_VAR_CLAUSE_PG18_SAFE(node, flags) \
+    pull_var_clause((node), (flags))
 #endif
 
 char *getOperatorString(Oid opoid);
@@ -59,7 +88,7 @@ extractColumns(List *reltargetlist, List *restrictinfolist)
     List *targetcolumns;
     Node *node = (Node *)lfirst(lc);
 
-    targetcolumns = pull_var_clause(node,
+    targetcolumns = PULL_VAR_CLAUSE_PG18_SAFE(node,
 #if PG_VERSION_NUM >= 90600
                                     PVC_RECURSE_AGGREGATES |
                                         PVC_RECURSE_PLACEHOLDERS);
@@ -74,7 +103,7 @@ extractColumns(List *reltargetlist, List *restrictinfolist)
   {
     List *targetcolumns;
     RestrictInfo *node = (RestrictInfo *)lfirst(lc);
-    targetcolumns = pull_var_clause((Node *)node->clause,
+    targetcolumns = PULL_VAR_CLAUSE_PG18_SAFE((Node *)node->clause,
 #if PG_VERSION_NUM >= 90600
                                     PVC_RECURSE_AGGREGATES |
                                         PVC_RECURSE_PLACEHOLDERS);
@@ -341,7 +370,7 @@ colnameFromVar(Var *var, PlannerInfo *root, FdwPlanState *planstate)
  */
 bool isAttrInRestrictInfo(Index relid, AttrNumber attno, RestrictInfo *restrictinfo)
 {
-  List *vars = pull_var_clause((Node *)restrictinfo->clause,
+  List *vars = PULL_VAR_CLAUSE_PG18_SAFE((Node *)restrictinfo->clause,
 #if PG_VERSION_NUM >= 90600
                                PVC_RECURSE_AGGREGATES |
                                    PVC_RECURSE_PLACEHOLDERS);

--- a/fdw/query.c
+++ b/fdw/query.c
@@ -528,6 +528,9 @@ findPaths(PlannerInfo *root, RelOptInfo *baserel, List *possiblePaths,
             NULL, /* default pathtarget */
 #endif
             nbrows,
+#if PG_VERSION_NUM >= 180000
+            0, /* disabled_nodes (PG18) */
+#endif
             startupCost,
 #if PG_VERSION_NUM >= 90600
             nbrows * baserel->reltarget->width,
@@ -538,6 +541,9 @@ findPaths(PlannerInfo *root, RelOptInfo *baserel, List *possiblePaths,
             NULL,
 #if PG_VERSION_NUM >= 90500
             NULL,
+#endif
+#if PG_VERSION_NUM >= 180000
+            NIL, /* fdw_restrictinfo (PG18) */
 #endif
             NULL);
 
@@ -574,7 +580,11 @@ deparse_sortgroup(PlannerInfo *root, Oid foreigntableid, RelOptInfo *rel)
 
     if ((expr = fdw_get_em_expr(ec, rel)))
     {
+#if PG_VERSION_NUM >= 180000
+      md->reversed = (key->pk_cmptype == COMPARE_GT);
+#else
       md->reversed = (key->pk_strategy == BTGreaterStrategyNumber);
+#endif
       md->nulls_first = key->pk_nulls_first;
       md->key = key;
 

--- a/fdw/query.c
+++ b/fdw/query.c
@@ -542,8 +542,8 @@ findPaths(PlannerInfo *root, RelOptInfo *baserel, List *possiblePaths,
 #if PG_VERSION_NUM >= 90500
             NULL,
 #endif
-#if PG_VERSION_NUM >= 180000
-            NIL, /* fdw_restrictinfo (PG18) */
+#if PG_VERSION_NUM >= 170000
+            NIL, /* fdw_restrictinfo (added in PG17) */
 #endif
             NULL);
 

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var fdwVersion = "2.2.4"
+var fdwVersion = "2.3.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
## What

Three localized, version-guarded source changes so the FDW compiles and links against PostgreSQL 18, with PostgreSQL 16-and-earlier behaviour **byte-identical** (every change is behind `#if PG_VERSION_NUM >= 180000`):

- `fdw/common.h` — include `commands/explain_format.h` on PG18 (PG18 split the EXPLAIN property-output API, incl. `ExplainPropertyText`, out of `commands/explain.h`).
- `fdw/query.c` — use `PathKey.pk_cmptype == COMPARE_GT` on PG18 (PG18 renamed `pk_strategy:int` → `pk_cmptype:CompareType`; `COMPARE_GT` is the documented equivalent of `BTGreaterStrategyNumber`). Pre-18 path unchanged in the `#else` arm.
- `fdw/fdw.c` (2 sites) + `fdw/query.c` (1 site) — pass the two new `create_foreignscan_path` arguments on PG18: `disabled_nodes = 0` (after `rows`) and `fdw_restrictinfo = NIL` (before `fdw_private`). `make_foreignscan` is unchanged in PG18 and left as-is.

Bumps `fdwVersion` 2.2.2 → 2.2.3 + CHANGELOG entry.

## Risk

Near-zero for the shipped product: the FDW ships built on PG14, where the preprocessor strips every change — byte-identical. The PG18 arms are inert on PG≤16 by construction.

## Testing

- PG18: `make` compiles + links (`steampipe_postgres_fdw.dylib`); only the pre-existing macOS `.so`/`.dylib` `inst`-step quirk remains.
- PG14: `make` exit 0, identical to the develop baseline (guards proven inert).
- `go test ./types/... ./sql/...`: no worse than develop baseline (`types/` green; `sql/ TestGetSQLForTable` already red on develop, unchanged — not introduced here).
- Every PG18 symbol verified against installed PG18 **and** PG14 headers before editing.

## Scope

This is a build-enablement change only — it does **not** flip any embedded version, tag, or publish any image. The FDW image tag/publish and the embedded-PG version flip are handled separately.