### PR TITLE
Release steampipe-postgres-fdw v2.2.3 (pgx v5.9.2, CVE-2026-41889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.2.3 [2026-05-19]
+_Dependencies_
+- Bump `github.com/jackc/pgx/v5` to `v5.9.2` to remediate `CVE-2026-41889` (`GHSA-j88v-2chj-qfwx`).
+
 ## v2.2.2 [2026-03-31]
 _Dependencies_
 - Upgrade `google.golang.org/grpc` to `v1.79.3` to address `CVE-2026-33186`.

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var fdwVersion = "2.2.2"
+var fdwVersion = "2.2.3"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
## Summary

Release-prep PR for **steampipe-postgres-fdw v2.2.3** on the `v2.2.x` line.

This PR adds the release-version metadata that the FDW release runbook requires **before** tagging:

- `version/version.go` — bump `fdwVersion` from `2.2.2` → `2.2.3`
- `CHANGELOG.md` — add the `v2.2.3 [2026-05-19]` entry under `_Dependencies_`

## Context

The actual pgx security fix — bumping `github.com/jackc/pgx/v5` to `v5.9.2` to remediate **CVE-2026-41889** (`GHSA-j88v-2chj-qfwx`) — is **already merged** on `v2.2.x` via #663. This PR carries only the version + changelog bookkeeping for that fix; no dependency/code changes are included here.

## Scope / next steps

- This is Phase A release-prep only (version.go + CHANGELOG).
- The `develop`/`main` release PRs and the `v2.2.3` tag are handled separately later (Phase C/D).
- **No merge, no tag, no release** as part of this PR.

## Target branch

Targets `v2.2.x` (the release line), **not** `main`/`develop`.