### PR TITLE
fix: honour statement_timeout when a plugin call hangs (#671)

### DIFF
--- a/fdw.go
+++ b/fdw.go
@@ -69,6 +69,13 @@ func init() {
 	if err := hub.CreateHub(); err != nil {
 		panic(err)
 	}
+	// install the cgo-backed bridge that lets the hub detect Postgres
+	// cancellation while a cgo call is in flight. Without this, a hung plugin
+	// gRPC stream leaves the backend stuck active and statement_timeout has no
+	// effect — see issue #671.
+	hub.SetQueryCancelChecker(func() bool {
+		return C.fdw_query_cancel_pending() != 0
+	})
 	log.Printf("[INFO] .\n******************************************************\n\n\t\tsteampipe postgres fdw init\n\n******************************************************\n")
 	log.Printf("[INFO] Version:   v%s\n", version.FdwVersion.String())
 	log.Printf("[INFO] Log level: %s\n", level)

--- a/fdw/fdw_helpers.h
+++ b/fdw/fdw_helpers.h
@@ -20,8 +20,18 @@
 #include "utils/syscache.h"
 #include "utils/lsyscache.h"
 #include "netinet/in.h"
+#include "miscadmin.h"
 
 extern char **environ;
+
+// Returns non-zero when the backend has a pending query-cancel or backend-die
+// request. The underlying flags are volatile sig_atomic_t (designed to be safe
+// to read from a signal handler), so reading them from a Go-scheduled
+// goroutine is safe. Used as a polling bridge from Postgres cancellation to
+// the iterator's Go context — see issue #671.
+static inline int fdw_query_cancel_pending(void) {
+  return (QueryCancelPending || ProcDiePending) ? 1 : 0;
+}
 
 // Macro expansions
 static inline FormData_pg_attribute *fdw_tupleDescAttr(TupleDesc tupdesc, int i) { return TupleDescAttr(tupdesc, i); }

--- a/hub/cancel.go
+++ b/hub/cancel.go
@@ -34,3 +34,10 @@ func isQueryCancelPending() bool {
 	}
 	return queryCancelChecker()
 }
+
+// queryCancelCheckerConfigured reports whether a cancellation checker has
+// been registered. Callers can use this to skip starting the per-scan
+// watcher goroutine entirely when the bridge isn't wired up.
+func queryCancelCheckerConfigured() bool {
+	return queryCancelChecker != nil
+}

--- a/hub/cancel.go
+++ b/hub/cancel.go
@@ -1,0 +1,36 @@
+package hub
+
+import "time"
+
+// queryCancelPollInterval is how often the per-scan watcher goroutine asks
+// Postgres whether the current backend has a pending cancellation. 250ms gives
+// sub-second responsiveness to statement_timeout / pg_cancel_backend without
+// noticeable cgo overhead (a single inline read of two sig_atomic_t globals).
+const queryCancelPollInterval = 250 * time.Millisecond
+
+// queryCancelChecker is set by the FDW (cgo) layer at init via
+// SetQueryCancelChecker. It returns true when Postgres has set
+// QueryCancelPending or ProcDiePending on the current backend. The hub uses
+// this from a polling goroutine to bridge Postgres cancellation into the
+// iterator's Go context, which is otherwise unreachable while the cgo
+// IterateForeignScan call is blocked on a hung plugin gRPC stream (issue
+// #671).
+var queryCancelChecker func() bool
+
+// SetQueryCancelChecker installs the function the hub uses to detect a
+// pending Postgres query-cancel or backend-die request. It is intended to be
+// called exactly once, from the FDW package's init(), with a cgo-backed
+// implementation.
+func SetQueryCancelChecker(fn func() bool) {
+	queryCancelChecker = fn
+}
+
+// isQueryCancelPending reports whether Postgres has requested cancellation of
+// the current backend. Returns false if no checker has been installed (e.g.
+// in unit tests that exercise the hub in isolation).
+func isQueryCancelPending() bool {
+	if queryCancelChecker == nil {
+		return false
+	}
+	return queryCancelChecker()
+}

--- a/hub/scan_iterator_base.go
+++ b/hub/scan_iterator_base.go
@@ -195,7 +195,15 @@ func (i *scanIteratorBase) Start(executor pluginExecutor) error {
 // die request and cancels the iterator's context when one is observed. Exits
 // naturally when the iterator's context is done (i.e. when the scan ends
 // normally and Close() has been called).
+//
+// Returns immediately if no cancellation checker has been installed (e.g.
+// hub used outside the FDW cgo init, or in unit tests). In that case there
+// is nothing useful for the watcher to do — keeping it running would just
+// add idle goroutines that can never trigger.
 func (i *scanIteratorBase) watchForCancellation(ctx context.Context) {
+	if !queryCancelCheckerConfigured() {
+		return
+	}
 	ticker := time.NewTicker(queryCancelPollInterval)
 	defer ticker.Stop()
 	for {

--- a/hub/scan_iterator_base.go
+++ b/hub/scan_iterator_base.go
@@ -183,7 +183,33 @@ func (i *scanIteratorBase) Start(executor pluginExecutor) error {
 
 	// read the results - this will loop until it hits an error or the stream is closed
 	go i.readThread(ctx)
+	// bridge Postgres cancellation (statement_timeout, pg_cancel_backend, etc.) into
+	// the iterator's context — without this, a hung plugin call leaves the cgo
+	// IterateForeignScan call blocked and Postgres has no way to recover the
+	// backend. See issue #671.
+	go i.watchForCancellation(ctx)
 	return nil
+}
+
+// watchForCancellation polls Postgres for a pending query cancel or backend
+// die request and cancels the iterator's context when one is observed. Exits
+// naturally when the iterator's context is done (i.e. when the scan ends
+// normally and Close() has been called).
+func (i *scanIteratorBase) watchForCancellation(ctx context.Context) {
+	ticker := time.NewTicker(queryCancelPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if isQueryCancelPending() {
+				log.Printf("[INFO] Postgres query cancel pending; cancelling iterator (%p)", i)
+				i.cancel()
+				return
+			}
+		}
+	}
 }
 
 // GetPluginName implements Iterator (this should be implemented by the concrete iterator)
@@ -288,8 +314,12 @@ func (i *scanIteratorBase) readThread(ctx context.Context) {
 
 func (i *scanIteratorBase) readPluginResult(ctx context.Context) bool {
 	continueReading := true
-	var rcvChan = make(chan *proto.ExecuteResponse)
-	var errChan = make(chan error)
+	// size-1 buffered so the inner Recv() goroutine can always complete its
+	// send and exit, even when the outer select below returns via ctx.Done()
+	// before Recv() unblocks. Without the buffer the inner goroutine leaks on
+	// every cancelled scan.
+	var rcvChan = make(chan *proto.ExecuteResponse, 1)
+	var errChan = make(chan error, 1)
 
 	// put the stream receive code into a goroutine to ensure cancellation is possible in case of a plugin hang
 	go func() {


### PR DESCRIPTION
## Summary
- Adds a polling bridge so Postgres cancellation (`statement_timeout`, `pg_cancel_backend`, `pg_terminate_backend`) reaches the iterator's Go context while the cgo `IterateForeignScan` call is in flight.
- Fixes a latent goroutine leak in `readPluginResult` by buffering its inner channels.

Closes #671.

## Background

Today, if a plugin's gRPC `Recv()` stalls (e.g. upstream API never responds), the backend executing the foreign scan ends up stuck inside `goFdwIterateForeignScan` → `iterator.Next()` → bare `<-i.rows` at `hub/scan_iterator_base.go:90`. Because the cgo call never returns, Postgres can't run `CHECK_FOR_INTERRUPTS` and `goFdwAbortCallback` (the `XactCallback` that would call `hub.Abort()` → `iterator.Close()` → `i.cancel()`) is never invoked. The session stays `active` forever, holding any locks it had picked up — most painfully `AccessShareLock` on parent tables of partitioned setups, which then blocks `ALTER TABLE … DETACH PARTITION` / `ATTACH PARTITION` indefinitely.

The cancellation **logic** is already in place — `readPluginResult` has a proper `select` on `<-ctx.Done()` — but the cancellation **signal** is never wired up to come from Postgres while the cgo call is blocked.

## Approach

A per-scan watcher goroutine that polls Postgres's interrupt-pending globals and cancels the iterator's context when it sees a request:

1. **`fdw/fdw_helpers.h`** — add `fdw_query_cancel_pending()` returning `QueryCancelPending || ProcDiePending`. These are `volatile sig_atomic_t` globals (designed to be read from a signal handler), so reading them from a Go goroutine on any OS thread is safe.

2. **`hub/cancel.go`** (new) — package-level `SetQueryCancelChecker(func() bool)` lets the cgo `main` package inject the check function without forcing a cgo dependency on the hub package. `queryCancelPollInterval` defaults to 250 ms (sub-second responsiveness, negligible overhead for an inline two-flag read).

3. **`hub/scan_iterator_base.go`** — in `Start()`, alongside the existing `go i.readThread(ctx)`, also `go i.watchForCancellation(ctx)`. The watcher tickers every 250 ms; on a pending cancel it calls `i.cancel()` and exits. It also exits naturally when the scan finishes (ctx becomes Done via `Close()`), so there's no goroutine leak in the happy path.

4. **`fdw.go`** — in `init()`, immediately after `hub.CreateHub()`, register the cgo-backed checker via `hub.SetQueryCancelChecker`.

5. **Bonus** — `readPluginResult`'s `rcvChan` / `errChan` were unbuffered. When the outer `select` returns via `<-ctx.Done()` before the inner `Recv()` returns, the inner goroutine's `errChan <- err` / `rcvChan <- rowResult` blocked forever (no receiver), leaking the goroutine on every cancelled scan. Both channels are now size-1 buffered.

## Cancel chain end to end

```
Postgres sets QueryCancelPending (statement_timeout / cancel / terminate)
   ↓ (polled every 250ms)
watchForCancellation → i.cancel()
   ↓
ctx.Done()
   ↓
readPluginResult's select fires <-ctx.Done(), returns false
   ↓
readThread for-loop exits → close(i.rows)
   ↓
Next() bare receive at line 90 unblocks (nil row from closed chan)
   ↓
goFdwIterateForeignScan returns to C
   ↓
Postgres ProcessInterrupts → "canceling statement due to statement timeout"
   ↓
locks released
```

## Risk / scope

- New behaviour is per-scan: one extra goroutine + one cgo call per 250 ms per active scan. Cgo call is an inline read of two atomics, so the overhead is negligible (a handful of nanoseconds).
- The buffered-channel change is purely defensive and only matters on the error / cancel paths.
- No protocol changes, no API changes, no behaviour change for queries that complete normally.
- Polling interval is currently a constant; if anyone wants it tunable later, it's a one-line change in `hub/cancel.go`.

## Reproduction (post-merge verification)

A reliable repro: a test plugin whose `List` hydrate function blocks on `<-(chan struct{})(nil)`. Without this PR, `SET statement_timeout = '15s'` followed by a select against that table runs indefinitely and `pg_locks` shows the session still holding `AccessShareLock` long after the timeout. With this PR, the statement is cancelled at ~15 s and the lock is released.