### PR TITLE
v2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.2.4 [2026-05-25]
+_Bug fixes_
+- Fix `statement_timeout`, `pg_cancel_backend`, and `pg_terminate_backend` having no effect when a plugin's gRPC stream stalls — a hung scan held `AccessShareLock` indefinitely, blocking partition swaps and other DDL until restart. ([#671](https://github.com/turbot/steampipe-postgres-fdw/issues/671), [#672](https://github.com/turbot/steampipe-postgres-fdw/pull/672))
+
 ## v2.2.3 [2026-05-19]
 _Dependencies_
 - Bump `github.com/jackc/pgx/v5` to `v5.9.2` to remediate `CVE-2026-41889` (`GHSA-j88v-2chj-qfwx`).

--- a/fdw.go
+++ b/fdw.go
@@ -69,6 +69,13 @@ func init() {
 	if err := hub.CreateHub(); err != nil {
 		panic(err)
 	}
+	// install the cgo-backed bridge that lets the hub detect Postgres
+	// cancellation while a cgo call is in flight. Without this, a hung plugin
+	// gRPC stream leaves the backend stuck active and statement_timeout has no
+	// effect — see issue #671.
+	hub.SetQueryCancelChecker(func() bool {
+		return C.fdw_query_cancel_pending() != 0
+	})
 	log.Printf("[INFO] .\n******************************************************\n\n\t\tsteampipe postgres fdw init\n\n******************************************************\n")
 	log.Printf("[INFO] Version:   v%s\n", version.FdwVersion.String())
 	log.Printf("[INFO] Log level: %s\n", level)

--- a/fdw/fdw_helpers.h
+++ b/fdw/fdw_helpers.h
@@ -20,8 +20,18 @@
 #include "utils/syscache.h"
 #include "utils/lsyscache.h"
 #include "netinet/in.h"
+#include "miscadmin.h"
 
 extern char **environ;
+
+// Returns non-zero when the backend has a pending query-cancel or backend-die
+// request. The underlying flags are volatile sig_atomic_t (designed to be safe
+// to read from a signal handler), so reading them from a Go-scheduled
+// goroutine is safe. Used as a polling bridge from Postgres cancellation to
+// the iterator's Go context — see issue #671.
+static inline int fdw_query_cancel_pending(void) {
+  return (QueryCancelPending || ProcDiePending) ? 1 : 0;
+}
 
 // Macro expansions
 static inline FormData_pg_attribute *fdw_tupleDescAttr(TupleDesc tupdesc, int i) { return TupleDescAttr(tupdesc, i); }

--- a/hub/cancel.go
+++ b/hub/cancel.go
@@ -34,3 +34,10 @@ func isQueryCancelPending() bool {
 	}
 	return queryCancelChecker()
 }
+
+// queryCancelCheckerConfigured reports whether a cancellation checker has
+// been registered. Callers can use this to skip starting the per-scan
+// watcher goroutine entirely when the bridge isn't wired up.
+func queryCancelCheckerConfigured() bool {
+	return queryCancelChecker != nil
+}

--- a/hub/cancel.go
+++ b/hub/cancel.go
@@ -1,0 +1,36 @@
+package hub
+
+import "time"
+
+// queryCancelPollInterval is how often the per-scan watcher goroutine asks
+// Postgres whether the current backend has a pending cancellation. 250ms gives
+// sub-second responsiveness to statement_timeout / pg_cancel_backend without
+// noticeable cgo overhead (a single inline read of two sig_atomic_t globals).
+const queryCancelPollInterval = 250 * time.Millisecond
+
+// queryCancelChecker is set by the FDW (cgo) layer at init via
+// SetQueryCancelChecker. It returns true when Postgres has set
+// QueryCancelPending or ProcDiePending on the current backend. The hub uses
+// this from a polling goroutine to bridge Postgres cancellation into the
+// iterator's Go context, which is otherwise unreachable while the cgo
+// IterateForeignScan call is blocked on a hung plugin gRPC stream (issue
+// #671).
+var queryCancelChecker func() bool
+
+// SetQueryCancelChecker installs the function the hub uses to detect a
+// pending Postgres query-cancel or backend-die request. It is intended to be
+// called exactly once, from the FDW package's init(), with a cgo-backed
+// implementation.
+func SetQueryCancelChecker(fn func() bool) {
+	queryCancelChecker = fn
+}
+
+// isQueryCancelPending reports whether Postgres has requested cancellation of
+// the current backend. Returns false if no checker has been installed (e.g.
+// in unit tests that exercise the hub in isolation).
+func isQueryCancelPending() bool {
+	if queryCancelChecker == nil {
+		return false
+	}
+	return queryCancelChecker()
+}

--- a/hub/scan_iterator_base.go
+++ b/hub/scan_iterator_base.go
@@ -195,7 +195,15 @@ func (i *scanIteratorBase) Start(executor pluginExecutor) error {
 // die request and cancels the iterator's context when one is observed. Exits
 // naturally when the iterator's context is done (i.e. when the scan ends
 // normally and Close() has been called).
+//
+// Returns immediately if no cancellation checker has been installed (e.g.
+// hub used outside the FDW cgo init, or in unit tests). In that case there
+// is nothing useful for the watcher to do — keeping it running would just
+// add idle goroutines that can never trigger.
 func (i *scanIteratorBase) watchForCancellation(ctx context.Context) {
+	if !queryCancelCheckerConfigured() {
+		return
+	}
 	ticker := time.NewTicker(queryCancelPollInterval)
 	defer ticker.Stop()
 	for {

--- a/hub/scan_iterator_base.go
+++ b/hub/scan_iterator_base.go
@@ -183,7 +183,33 @@ func (i *scanIteratorBase) Start(executor pluginExecutor) error {
 
 	// read the results - this will loop until it hits an error or the stream is closed
 	go i.readThread(ctx)
+	// bridge Postgres cancellation (statement_timeout, pg_cancel_backend, etc.) into
+	// the iterator's context — without this, a hung plugin call leaves the cgo
+	// IterateForeignScan call blocked and Postgres has no way to recover the
+	// backend. See issue #671.
+	go i.watchForCancellation(ctx)
 	return nil
+}
+
+// watchForCancellation polls Postgres for a pending query cancel or backend
+// die request and cancels the iterator's context when one is observed. Exits
+// naturally when the iterator's context is done (i.e. when the scan ends
+// normally and Close() has been called).
+func (i *scanIteratorBase) watchForCancellation(ctx context.Context) {
+	ticker := time.NewTicker(queryCancelPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if isQueryCancelPending() {
+				log.Printf("[INFO] Postgres query cancel pending; cancelling iterator (%p)", i)
+				i.cancel()
+				return
+			}
+		}
+	}
 }
 
 // GetPluginName implements Iterator (this should be implemented by the concrete iterator)
@@ -288,8 +314,12 @@ func (i *scanIteratorBase) readThread(ctx context.Context) {
 
 func (i *scanIteratorBase) readPluginResult(ctx context.Context) bool {
 	continueReading := true
-	var rcvChan = make(chan *proto.ExecuteResponse)
-	var errChan = make(chan error)
+	// size-1 buffered so the inner Recv() goroutine can always complete its
+	// send and exit, even when the outer select below returns via ctx.Done()
+	// before Recv() unblocks. Without the buffer the inner goroutine leaks on
+	// every cancelled scan.
+	var rcvChan = make(chan *proto.ExecuteResponse, 1)
+	var errChan = make(chan error, 1)
 
 	// put the stream receive code into a goroutine to ensure cancellation is possible in case of a plugin hang
 	go func() {

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var fdwVersion = "2.2.3"
+var fdwVersion = "2.2.4"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Release v2.2.4 — backports #672 (statement_timeout fix) onto v2.2.x.

Closes #671.

## Changes
- `version/version.go`: bump to 2.2.4
- `CHANGELOG.md`: v2.2.4 entry
- Cherry-pick of #672 commits (statement_timeout / pg_cancel_backend / pg_terminate_backend now honoured when a plugin's gRPC stream stalls)

## Verification
Reproduced the bug on stock v2.2.3 and verified the fix locally:
- **Unfixed**: query hung past `statement_timeout=15s` (94s elapsed, `state=active`, `wait_event=∅`, `AccessShareLock` held). `pg_cancel_backend` and `pg_terminate_backend` both returned `t` but had no effect.
- **Fixed**: query cancelled at exactly 15s with `ERROR: canceling statement due to statement timeout`. Lock released.
