### PR TITLE
fix: mark standalone FDW as parallel-safe in handler template

### DIFF
--- a/templates/fdw/fdw_handlers.h.tmpl
+++ b/templates/fdw/fdw_handlers.h.tmpl
@@ -13,6 +13,7 @@ static ForeignScan *fdwGetForeignPlan(
     List *scan_clauses,
     Plan *outer_plan
 );
+static bool fdwIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte);
 
 // Define our handling functions with Postgres, following the V1 protocol.
 PG_FUNCTION_INFO_V1(steampipe_{{.Plugin}}_fdw_handler);
@@ -21,6 +22,7 @@ PG_FUNCTION_INFO_V1(steampipe_{{.Plugin}}_fdw_validator);
 
 Datum steampipe_{{.Plugin}}_fdw_handler(PG_FUNCTION_ARGS) {
   FdwRoutine *fdw_routine = makeNode(FdwRoutine);
+  fdw_routine->IsForeignScanParallelSafe = fdwIsForeignScanParallelSafe;
   fdw_routine->GetForeignRelSize = fdwGetForeignRelSize;
   fdw_routine->GetForeignPaths = fdwGetForeignPaths;
   fdw_routine->GetForeignPlan = fdwGetForeignPlan;


### PR DESCRIPTION
## What

`IsForeignScanParallelSafe` was added in #366 (closing #428), but the wiring only ever landed in the in-process handler (`fdw/fdw_handlers.h`). The standalone handler is generated from `templates/fdw/fdw_handlers.h.tmpl`, which was never updated to wire it — so plugins built with `make standalone` end up with `FdwRoutine.IsForeignScanParallelSafe == NULL`.

## Why it matters

In PostgreSQL's `set_rel_consider_parallel()` (`optimizer/path/allpaths.c`), the foreign-table branch is:

```c
if (rte->relkind == RELKIND_FOREIGN_TABLE)
{
    Assert(rel->fdwroutine);
    if (!rel->fdwroutine->IsForeignScanParallelSafe)
        return;                                   /* <- bails for standalone builds */
    if (!rel->fdwroutine->IsForeignScanParallelSafe(root, rel, rte))
        return;
}
```

With the callback NULL it returns before `consider_parallel` is set, so foreign scans are never marked parallel-safe. Net effect: on standalone builds `STEAMPIPE_FDW_PARALLEL_SAFE` has no effect — the #366 feature is inert for them (it still works for the in-process handler). `GetForeignPaths` *is* wired in the template, so planning otherwise looks normal, which makes this easy to miss.

## Repro (standalone build, PG 18)

```sql
SET max_parallel_workers_per_gather = 8;
SET parallel_setup_cost = 0;
SET parallel_tuple_cost = 0;
-- with STEAMPIPE_FDW_PARALLEL_SAFE set in the server environment
EXPLAIN (COSTS OFF)
  SELECT name, region FROM aws_api_gateway_rest_api
  UNION ALL SELECT name, region FROM aws_api_gatewayv2_api
  UNION ALL SELECT name, region FROM aws_ec2_autoscaling_group;
```

Before — plain serial `Append`:

```
Append
  ->  Foreign Scan on aws_api_gateway_rest_api
  ->  Foreign Scan on aws_api_gatewayv2_api
  ->  Foreign Scan on aws_ec2_autoscaling_group
```

After this patch — parallel again:

```
Gather
  Workers Planned: 2
  ->  Parallel Append
        ->  Foreign Scan on aws_api_gateway_rest_api
        ->  Foreign Scan on aws_api_gatewayv2_api
        ->  Foreign Scan on aws_ec2_autoscaling_group
```

## Fix

Wire `IsForeignScanParallelSafe` in the template, matching the in-process handler. The function is already defined in `fdw.c`, so it's just the missing declaration + assignment.

Verified by building the AWS plugin standalone on PG 18.4 and comparing `EXPLAIN` before/after (plans above); confirmed the callback is now invoked during planning.
