### PR TITLE
Bump Go 1.26.1 → 1.26.4 to clear go-runtime CVEs in the FDW .so

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -251,7 +251,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -336,7 +336,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Checkout Steampipe
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-postgres-fdw/v2
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/dgraph-io/ristretto v0.2.0 // indirect


### PR DESCRIPTION
## Problem

`steampipe_postgres_fdw.so` built from this repo is compiled with **Go 1.26.1**. Turbot Pipes bundles it into the `workspace` container image (via the Steampipe CLI), where GCP Artifact Registry scanning flags it for **14 Go standard-library CVEs**, including:

- **CVE-2026-27143** (CRITICAL) — fixed in Go 1.26.2
- CVE-2026-33810/33811/33814/39820/39836/42499/42501 — fixed in Go 1.26.2–1.26.3
- **CVE-2026-42504** — fixed in **Go 1.26.4**

Every one of these findings is in the FDW `.so` (confirmed via the scan `fileLocation`), so they clear simply by compiling with a patched Go runtime.

## Change

- `go.mod`: `go 1.26.1 → 1.26.4`
- CI `setup-go` pins → `1.26.4`: `buildimage.yml` (release build, ×4) and `test.yml` (×2)

The CI pin is the one that actually stamps the runtime into the released `.so`, so both the directive and the pins are bumped (mirrors turbot/pipes#6738).

## Pairs with

- #684 (Dependabot: `containerd` 1.7.29 → 1.7.33) — clears the FDW's remaining `containerd` CVEs (CVE-2026-46680/-53488). Both this PR and #684 are needed to fully clear the FDW findings.

## Downstream

A Steampipe CLI release picking up the new FDW is required for the fix to reach the Pipes `workspace` image; tracked in the sibling `turbot/steampipe` Go bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)