### PR TITLE
Bump Go to 1.26.7 to clear CVE-2026-39821 (GO-2026-5026, CVSS 9.6)

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -251,7 +251,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -336,7 +336,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.7
 
       - name: Checkout Steampipe
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-postgres-fdw/v2
 
-go 1.26.1
+go 1.26.7
 
 require (
 	github.com/dgraph-io/ristretto v0.2.0 // indirect


### PR DESCRIPTION
Closes #695.

## What this changes

Bumps the Go toolchain from **1.26.1 to 1.26.7** in two places:

- `go.mod` — the `go` directive
- `.github/workflows/` — all six `go-version:` pins (`test.yml` ×2, `buildimage.yml` ×4)

That is the entire diff: 7 changed lines across 3 files. No dependency changes, no code changes, no `toolchain` directive, no `go get`/`go mod tidy`, no other workflow inputs touched.

## Why a toolchain bump is the fix

CVE-2026-39821 (GO-2026-5026, CVSS 9.6) is a hostname-validation bypass in `idna`. `ToASCII`/`ToUnicode` wrongly accept Punycode-encoded labels that decode to an ASCII-only label — `ToUnicode("xn--example-.com")` returns `"example.com"` instead of an error. Any caller that allowlists or filters on the ASCII hostname can be bypassed by submitting the encoded spelling instead.

Fixed in Go 1.26.6 / 1.25.13 / 1.27.0-rc.3, and in `golang.org/x/net` v0.55.0.

The copy that matters for this repo is the one **vendored into the Go standard library** and reachable through `net/http` — which is why bumping a module dependency does not help. `golang.org/x/net` is already at **v0.56.0** here (well past the fixed v0.55.0), so it is deliberately left alone. The only remaining exposure is the stdlib copy baked in by the compiler, and the only way to change that is to compile with a fixed toolchain.

1.26.7 is chosen as the latest 1.26.x — it carries the 1.26.6 security content plus subsequent `net/http` bugfixes. Not 1.27.x, which would be a language-version change rather than a patch.

## Note on the develop pin

`develop` was pinned to 1.26.1, which is *behind* the release branch — the shipped `v2.2.5` tag (2026-08-10) was built with go1.26.5. So the `develop` pin had regressed relative to what actually ships. This PR brings both forward to 1.26.7.

Worth stating plainly: v2.2.5 shipped on 2026-08-10, three days *before* go1.26.6 existed. This is a release-timing gap, not neglect. But it does mean the currently-published artifact is vulnerable and a rebuild is required.

## Downstream impact

Turbot Pipes bundles `steampipe_postgres_fdw.so` into its `workspace` container image. Extracting the binaries from the built image `workspace@sha256:7f5ab7a3f39a` (v1.22.46-rc.1) and running `go version -m`, on 2026-08-31:

```
.../postgres/lib/postgresql/steampipe_postgres_fdw.so   go1.26.5   golang.org/x/net v0.54.0   <- 2 CRITICAL findings
```

Alongside the Steampipe and Powerpipe CLIs (same root cause, separate PRs), this `.so` accounts for the **only remaining CRITICAL findings** on that image. Pipes has already fixed its own binary — turbot/pipes#6801 moved `/opt/steampipe/steampipe-server` from Go 1.26.5 to 1.26.7, and `govulncheck -mode=binary` confirmed GO-2026-5026 went from CALLED (17 reachable symbols via `http.Client.Do`/`Get`/`Post`) to absent.

Pipes cannot fix this one itself: the FDW version is selected by Steampipe's compiled-in `FdwVersion` constant (`pkg/constants/db.go`, currently `"2.2.5"` → `ghcr.io/turbot/steampipe/fdw:2.2.5`). It needs a rebuilt FDW release from this repo.

## What I verified, and what I did not

Verified locally:

- The new `go` directive resolves and is actually used — inside the module, `go version` reports `go1.26.7 darwin/arm64` (GOTOOLCHAIN=auto fetched the 1.26.7 toolchain successfully).
- `go build ./hub/... ./settings/... ./sql/... ./types/... ./version/...` — **passes**, exit 0, no output.
- `go vet` on those same packages reports one finding, `hub/hub_base.go:46:9: return copies lock value`. That is **pre-existing on `develop`** and unrelated to this change; I did not touch it.
- `go.sum` is unchanged; `git status` shows only the three intended files.

**Not verified — CGO build of the extension itself.** The root package is a PostgreSQL extension built via CGO against PG 14 server headers (build tag `pg14`, headers normally supplied by the Steampipe-bundled PostgreSQL 14.17). This machine only has Homebrew `libpq` at **PostgreSQL 18.6**, so the compile fails on an API mismatch:

```
../explain.go:28:2: could not determine what C.ExplainPropertyText refers to
```

That is a PG-header-version mismatch, not a Go toolchain problem — but I want to be explicit that I did **not** see the `.so` build succeed on this change. CI (`buildimage.yml`) exercises the real build with the correct headers and is the gate for that.

I also have not run the acceptance tests, and I have not verified `govulncheck` against a rebuilt `.so` (that requires a build I could not perform).

## After merge

A tagged release is still needed to actually clear the finding downstream — the fix only reaches Pipes once a rebuilt FDW image is published and Steampipe's `FdwVersion` points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
