### PR TITLE
Backport: Bump Go to 1.26.7 to clear CVE-2026-39821 (GO-2026-5026)

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -251,7 +251,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -336,7 +336,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Checkout Steampipe
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe-postgres-fdw/v2
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/dgraph-io/ristretto v0.2.0 // indirect


### PR DESCRIPTION
Cherry-pick of 1ac9264 (#699, merged to develop) onto v2.2.x so the fix ships in the next FDW patch release.

Resolves trivial conflicts against v2.2.x's existing Go 1.26.5 pin (go.mod, buildimage.yml, test.yml) - all resolved to 1.26.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
